### PR TITLE
Anfuehrungszeichen korrigiert

### DIFF
--- a/exported/localized/de_patch/text/conversations/03_neketaka_vailian_district/03_cv_abocco.stringtable
+++ b/exported/localized/de_patch/text/conversations/03_neketaka_vailian_district/03_cv_abocco.stringtable
@@ -401,8 +401,8 @@ Angesichts des Flecks auf seiner Hose seufzt Abocco.</DefaultText>
     </Entry>
     <Entry>
       <ID>82</ID>
-      <DefaultText>„Du kommst mir bekannt vor, Freund … Abocco durchwühlt seine Notizen, bevor er mit den Schultern zuckt und aufgibt.“</DefaultText>
-      <FemaleText>„Du kommst mir bekannt vor, gute Freundin … Abocco durchwühlt seine Notizen, bevor er mit den Schultern zuckt und aufgibt.“</FemaleText>
+      <DefaultText>„Du kommst mir bekannt vor, Freund …“, Abocco durchwühlt seine Notizen, bevor er mit den Schultern zuckt und aufgibt.</DefaultText>
+      <FemaleText>„Du kommst mir bekannt vor, gute Freundin …“, Abocco durchwühlt seine Notizen, bevor er mit den Schultern zuckt und aufgibt.</FemaleText>
     </Entry>
     <Entry>
       <ID>83</ID>


### PR DESCRIPTION
Ich bin mir bei dem FemaleText nicht sicher, ob er ueberhaupt existieren sollte. Dieser Text von Abocco taucht nach einem Spruch von Serafen auf und bezog sich so vom Lesefluss auch auf diesen und nicht auf meinen weiblichen Hauptcharakter. Habe es aber vorsichtshalber noch drin belassen.