### PR TITLE
Ondra ist eine Person/Göttin, also "zu Ondra", nicht "nach O."

### DIFF
--- a/exported/localized/de_patch/text/conversations/17_dunnage/17_cv_principi_boss_portmaje_shallows.stringtable
+++ b/exported/localized/de_patch/text/conversations/17_dunnage/17_cv_principi_boss_portmaje_shallows.stringtable
@@ -527,7 +527,7 @@ Serafen dreht sich zu dir und verbeugt sich wieder.</DefaultText>
       <ID>149</ID>
       <DefaultText>&lt;i&gt;Die Szene wogt davon, eiskalt und kratzend, ersetzt mit der Besatzung an Deck, die ernst zusieht, wie Furrante einen der ihren an der Kehle packt. Nein, nicht einen der ihren, nicht mehr. Wer von der Familie stiehlt, gehört nicht mehr zu Familie.
 
-Tränen und Schleim verunstalten den Mann, als Furrante ihm seine Grabesrede gibt. Dieb oder nicht, sie schicken ihn nach Ondra wie es die Tradition verlangt …&lt;/i&gt;</DefaultText>
+Tränen und Schleim verunstalten den Mann, als Furrante ihm seine Grabesrede gibt. Dieb oder nicht, sie schicken ihn zu Ondra, wie es die Tradition verlangt …&lt;/i&gt;</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>


### PR DESCRIPTION
wie die Überschrift sagt. Außerdem Komma ergänzt.