### PR TITLE
LAX3 Änderungen

### DIFF
--- a/lax3_exported/localized/de_patch/text/conversations/05_neketaka_artisans_district/05_si_circle_of_archmagi.stringtable
+++ b/lax3_exported/localized/de_patch/text/conversations/05_neketaka_artisans_district/05_si_circle_of_archmagi.stringtable
@@ -21,12 +21,12 @@
     </Entry>
     <Entry>
       <ID>160</ID>
-      <DefaultText>Ich half Bekarna einen Zauber zu schreiben. Sie sollte mit uns an diesem Tisch sitzen.</DefaultText>
+      <DefaultText>„Ich half Bekarna einen Zauber zu schreiben. Sie sollte mit uns an diesem Tisch sitzen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>161</ID>
-      <DefaultText>Solche Dinge werden zu ihrer Zeit besprochen. Als das aufgeregte Gemurmel immer lauter wird, bringt Arkemyr es mit einem Blick zum Schweigen.</DefaultText>
+      <DefaultText>„Solche Dinge werden zu ihrer Zeit besprochen.“ Als das aufgeregte Gemurmel immer lauter wird, bringt Arkemyr es mit einem Blick zum Schweigen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -71,7 +71,7 @@
     </Entry>
     <Entry>
       <ID>170</ID>
-      <DefaultText>Ich wurde über Mauras Schicksal informiert. Schade, dass sie nicht hier mit uns sein wird. Arkemyr blickt zu dem Paar.</DefaultText>
+      <DefaultText>„Ich wurde über Mauras Schicksal informiert. Schade, dass sie nicht hier mit uns sein wird.“ Arkemyr blickt zu dem Paar.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -91,23 +91,23 @@
     </Entry>
     <Entry>
       <ID>177</ID>
-      <DefaultText>"Wie ich sehe, ist es nicht das erste Mal, dass wir dich mit lästigen Dingen beschäftigt haben. Mögen das Protokoll zeigen, dass wir ... &lt;i&gt;deine Beiträge schätzen.&lt;/i&gt;" Arkemyr rümpft die Nase. </DefaultText>
+      <DefaultText>„Wie ich sehe, ist es nicht das erste Mal, dass wir dich mit lästigen Dingen beschäftigt haben. Möge das Protokoll zeigen, dass wir … &lt;i&gt;deine Beiträge schätzen.&lt;/i&gt;“ Arkemyr rümpft die Nase.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>178</ID>
-      <DefaultText>"Wie ich sehe, ist es nicht das erste Mal, dass wir dich mit lästigen Dingen beschäftigt haben. Mögen das Protokoll zeigen, dass wir ... &lt;i&gt;deine Beiträge schätzen.&lt;/i&gt;" Arkemyr rümpft die Nase. </DefaultText>
+      <DefaultText>„Wie ich sehe, ist es nicht das erste Mal, dass wir dich mit lästigen Dingen beschäftigt haben. Möge das Protokoll zeigen, dass wir … &lt;i&gt;deine Beiträge schätzen.&lt;/i&gt;“ Arkemyr rümpft die Nase.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>181</ID>
-      <DefaultText>Tayn spricht. "Ganz meine Meinung. Nicht, dass wir abstimmen würden. Oder etwa doch? Ich habe nicht ganz aufgepasst." </DefaultText>
+      <DefaultText>Tayn spricht. „Ganz meine Meinung. Nicht, dass wir abstimmen würden. Oder etwa doch? Ich habe nicht ganz aufgepasst.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>183</ID>
-      <DefaultText>Der Zirkel schätzt zweifelsohne [Player Name], Wächter von Caed Nua? Arkemyr gestikuliert zu dir. Die Personen am Tisch nicken feierlich.</DefaultText>
-      <FemaleText>Der Zirkel schätzt zweifelsohne [Player Name], Wächterin von Caed Nua? Arkemyr gestikuliert zu dir. Die Personen am Tisch nicken feierlich.</FemaleText>
+      <DefaultText>„Der Zirkel schätzt zweifelsohne [Player Name], Wächter von Caed Nua?“ Arkemyr zeigt auf dich. Die Personen am Tisch nicken feierlich.</DefaultText>
+      <FemaleText>„Der Zirkel schätzt zweifelsohne [Player Name], Wächterin von Caed Nua?“ Arkemyr zeigt auf dich. Die Personen am Tisch nicken feierlich.</FemaleText>
     </Entry>
     <Entry>
       <ID>184</ID>
@@ -121,17 +121,17 @@
     </Entry>
     <Entry>
       <ID>186</ID>
-      <DefaultText>"Der Wächter hat sich in den Verschleierten Hallen wacker geschlagen. Wir könnten ihn in der Zukunft mit mehr Arbeit beauftragen." Llengrath nickt dir zu.</DefaultText>
-      <FemaleText>"Die Wächterin hat sich in den Verschleierte Hallen wacker geschlagen. Wir könnten sie in der Zukunft mit mehr Arbeit beauftragen." Llengrath nickt dir zu.</FemaleText>
+      <DefaultText>„Der Wächter hat sich in den Verschleierten Hallen wacker geschlagen. Wir könnten ihn in der Zukunft mit mehr Arbeit beauftragen.“ Llengrath nickt dir zu.</DefaultText>
+      <FemaleText>„Die Wächterin hat sich in den Verschleierten Hallen wacker geschlagen. Wir könnten sie in der Zukunft mit mehr Arbeit beauftragen.“ Llengrath nickt dir zu.</FemaleText>
     </Entry>
     <Entry>
       <ID>187</ID>
-      <DefaultText>"Die Leistung des Wächters während der Wael-Situation ließ zu wünschen übrig." Llengrath wirft dir einen beredtem Blick zu.
+      <DefaultText>„Die Leistung des Wächters während der Wael-Situation ließ zu wünschen übrig.“ Llengrath wirft dir einen beredten Blick zu.
 
-"Ich würde nicht empfehlen, noch einmal mit ihm zu arbeiten."</DefaultText>
-      <FemaleText>"Die Leistung der Wächterin während der Wael-Situation ließ zu wünschen übrig." Llengrath wirft dir einen beredtem Blick zu.
+„Ich würde nicht empfehlen, noch einmal mit ihm zu arbeiten.“</DefaultText>
+      <FemaleText>„Die Leistung der Wächterin während der Wael-Situation ließ zu wünschen übrig.“ Llengrath wirft dir einen beredten Blick zu.
 
-"Ich würde nicht empfehlen, noch einmal mit ihr zu arbeiten."</FemaleText>
+„Ich würde nicht empfehlen, noch einmal mit ihr zu arbeiten.“</FemaleText>
     </Entry>
     <Entry>
       <ID>188</ID>

--- a/lax3_exported/localized/de_patch/text/conversations/12_ukaizo/12_cv_companions_ukaizo.stringtable
+++ b/lax3_exported/localized/de_patch/text/conversations/12_ukaizo/12_cv_companions_ukaizo.stringtable
@@ -6,12 +6,12 @@
   <Entries>
     <Entry>
       <ID>42</ID>
-      <DefaultText>"Das schlägt den Dunkeln Schrank, was Fassina?" </DefaultText>
+      <DefaultText>„Das schlägt den Dunklen Schrank, was, Fassina?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>43</ID>
-      <DefaultText>Was kommt danach, Rekke?</DefaultText>
+      <DefaultText>„Was kommt danach, Rekke?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -31,7 +31,7 @@
     </Entry>
     <Entry>
       <ID>47</ID>
-      <DefaultText>Bist du bereit, die Dämmerung zu sprechen, Vatnir?</DefaultText>
+      <DefaultText>„Bist du bereit, die Dämmerung zu sprechen, Vatnir?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -53,12 +53,12 @@ Wütend bindet er seine Haare zu einem schlampigen Dutt zusammen und stützt sei
     </Entry>
     <Entry>
       <ID>51</ID>
-      <DefaultText>"Würde ich doch nicht besser kennen, Wächter, müsste ich mich fragen, ob du gerade einen Todeswunsch hegst."
+      <DefaultText>„Würde ich dich nicht besser kennen, Wächter, müsste ich mich fragen, ob du gerade einen Todeswunsch hegst.“
 
-Kichernd wirft er einen längeren Blick auf die ruinierte Szene um ihn herum und auf die sich erhebende Form Eothas in der Ferne, und stößt dann einen Seufzer aus.</DefaultText>
-      <FemaleText>"Würde ich doch nicht besser kennen, Wächterin, müsste ich mich fragen, ob du gerade einen Todeswunsch hegst."
+Kichernd wirft er einen längeren Blick auf die ruinierte Szene um ihn herum und auf die Figur von Eothas, die sich in der Ferne erhebt, und stößt dann einen Seufzer aus.</DefaultText>
+      <FemaleText>„Würde ich dich nicht besser kennen, Wächterin, müsste ich mich fragen, ob du gerade einen Todeswunsch hegst.“
 
-Kichernd wirft er einen längeren Blick auf die ruinierte Szene um ihn herum und auf die sich erhebende Form Eothas in der Ferne, und stößt dann einen Seufzer aus.</FemaleText>
+Kichernd wirft er einen längeren Blick auf die ruinierte Szene um ihn herum und auf die Figur von Eothas, die sich in der Ferne erhebt, und stößt dann einen Seufzer aus.</FemaleText>
     </Entry>
     <Entry>
       <ID>52</ID>
@@ -104,7 +104,7 @@ Kichernd wirft er einen längeren Blick auf die ruinierte Szene um ihn herum und
     </Entry>
     <Entry>
       <ID>61</ID>
-      <DefaultText>Es ist ein Privileg. Selbst wenn ich &lt;i&gt;nur&lt;/i&gt; über deine Schulter blicke. Er knufft dich leicht auf den Arm und grinst. Als Licht in seine Augen fällt, leuchten sie auf.</DefaultText>
+      <DefaultText>„Es ist ein Privileg. Selbst wenn ich &lt;i&gt;nur&lt;/i&gt; über deine Schulter blicke.“ Er knufft dich leicht auf den Arm und grinst. Als Licht in seine Augen fällt, leuchten sie auf.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -114,11 +114,11 @@ Kichernd wirft er einen längeren Blick auf die ruinierte Szene um ihn herum und
     </Entry>
     <Entry>
       <ID>65</ID>
-      <DefaultText>"Ke tetahi ... Nan ke tagawu, elabe ke hunir."
+      <DefaultText>„Ke tetahi ... Nan ke tagawu, elabe ke hunir.“
 
-Rekkes schmale Schultern krümmen sich nach vorne. Er lässt sich seine Haare ins Gesicht fallen.
+Rekkes schmale Schultern krümmen sich nach vorne. Er lässt seine Haare ins Gesicht fallen.
 
-Für einen Mann, der eine solche qualvolle Reise überlebt hat, sieht er einen Moment lang sehr zerbrechlich aus.</DefaultText>
+Für einen Mann, der eine solch qualvolle Reise überlebt hat, sieht er einen Moment lang sehr zerbrechlich aus.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -141,9 +141,9 @@ Schließlich schüttelt er den Kopf.</DefaultText>
     </Entry>
     <Entry>
       <ID>68</ID>
-      <DefaultText>"Was danach passiert, ist in Gottes Händen. Aber jetzt ... jetzt würde ich gern bei dir bleiben.
+      <DefaultText>„Was danach passiert, ist in Gottes Händen. Aber jetzt … jetzt würde ich gern bei dir bleiben.“
 
-"Wenn du das willst."</DefaultText>
+„Wenn du das willst.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -185,7 +185,7 @@ Aber als du dich wegdrehst, bemerkst du ein Stirnrunzeln. Er sieht deinen Blick 
     </Entry>
     <Entry>
       <ID>78</ID>
-      <DefaultText> "Wer kann das schon sagen? Es spielt keine Rolle. Lass uns erledigen, wofür du hergekommen bist, und dann gehen wir."</DefaultText>
+      <DefaultText>„Wer kann das schon sagen? Es spielt keine Rolle. Lass uns erledigen, wofür du hergekommen bist, und dann gehen wir.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -195,12 +195,12 @@ Aber als du dich wegdrehst, bemerkst du ein Stirnrunzeln. Er sieht deinen Blick 
     </Entry>
     <Entry>
       <ID>80</ID>
-      <DefaultText>Egal. Wir sind jetzt hier und ich bin bereit. Lass uns das beenden.</DefaultText>
+      <DefaultText>„Egal. Wir sind jetzt hier und ich bin bereit. Lass uns das beenden.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>81</ID>
-      <DefaultText>Hört sich irgendwie an, als &lt;i&gt;willst&lt;/i&gt; du, dass Eothas obsiegt.</DefaultText>
+      <DefaultText>„Hört sich irgendwie an, als &lt;i&gt;willst&lt;/i&gt; du, dass Eothas obsiegt.“</DefaultText>
       <FemaleText />
     </Entry>
   </Entries>

--- a/lax3_exported/localized/de_patch/text/conversations/lax/lax_cv_craftsperson.stringtable
+++ b/lax3_exported/localized/de_patch/text/conversations/lax/lax_cv_craftsperson.stringtable
@@ -53,7 +53,7 @@ Die Zwergin nähert sich dir. Die Luft um sie herum riecht scharf nach Öl und M
     </Entry>
     <Entry>
       <ID>11</ID>
-      <DefaultText>"Was ist das denn? Eine Art Hauer, die du irgendeiner Kreatur gestohlen hast?" Sie bewundert den Zahn von Toamowhai und gibt ihn dir dann zurück.</DefaultText>
+      <DefaultText>„Was ist das denn? Eine Art Hauer, die du irgendeiner Kreatur gestohlen hast?“ Sie bewundert den Zahn des Toamowhai und gibt ihn dir dann zurück.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -63,7 +63,7 @@ Die Zwergin nähert sich dir. Die Luft um sie herum riecht scharf nach Öl und M
     </Entry>
     <Entry>
       <ID>13</ID>
-      <DefaultText>Ich bin diejenige, die das entscheidet. Und jetzt sei still!</DefaultText>
+      <DefaultText>„Ich bin diejenige, die das entscheidet. Und jetzt sei still!“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -126,7 +126,7 @@ Sie wendet den Blick ab und hustet leise.</DefaultText>
     </Entry>
     <Entry>
       <ID>29</ID>
-      <DefaultText>Ich kann mich nur noch daran erinnern, wie eine Frau diesen Beutel geöffnet und mir drei Stücke dunkles Metall gegeben hat. Sie erklärte mir, sie habe sie verloren. Aber wenn ich meine Augen aufhalten würde, so hat sie mir versprochen, würde ich sie eines Tages wieder finden.</DefaultText>
+      <DefaultText>„Ich kann mich nur noch daran erinnern, wie eine Frau diesen Beutel geöffnet und mir drei Stücke dunkles Metall gegeben hat. Sie erklärte mir, sie habe sie verloren. Aber wenn ich meine Augen aufhalten würde, so hat sie mir versprochen, würde ich sie eines Tages wiederfinden.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -145,7 +145,7 @@ Sie greift sich ein Tuch, mit dem sie dir vorsichtig die Stücke leuchtendes Met
     </Entry>
     <Entry>
       <ID>32</ID>
-      <DefaultText>[Ihr Neriscyrlas Hoffnung, Zahn des Toamowhai und das Gewicht der Offenbarung geben.] "Kannst du diese drei Einzelteile in ein Ganzes schmieden?"</DefaultText>
+      <DefaultText>[Ihr Neriscyrlas Hoffnung, den Zahn des Toamowhai und das Gewicht der Offenbarung geben.] „Kannst du diese drei Einzelteile zu einem Ganzen schmieden?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -184,7 +184,7 @@ Lächelnd präsentiert dir Izzia die Früchte ihrer Arbeit.</DefaultText>
     </Entry>
     <Entry>
       <ID>41</ID>
-      <DefaultText>[Ihr Toamowhais Zahn und das Gewicht der Offenbarung geben.] "Was kannst du mir aus diesen beiden Artefakten schmieden?"</DefaultText>
+      <DefaultText>[Ihr den Zahn des Toamowhai und das Gewicht der Offenbarung geben.] „Was kannst du mir aus diesen beiden Artefakten schmieden?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -211,7 +211,7 @@ Izzia übergibt dir einen mit Juwelen besetzten Kopfschmuck, der sich bei Berüh
     </Entry>
     <Entry>
       <ID>46</ID>
-      <DefaultText>Mir haben ein paar Attentäter aufgelauert, die deinen Namen erwähnt haben.</DefaultText>
+      <DefaultText>„Mir haben ein paar Attentäter aufgelauert, die deinen Namen erwähnt haben.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -308,9 +308,9 @@ Sie betrachtet dich prüfend von Kopf bis Fuß und nickt zustimmend.</DefaultTex
     </Entry>
     <Entry>
       <ID>70</ID>
-      <DefaultText>"Ganz besondere Materialien, seltene Metalle - vor allem wenn sie so &lt;i&gt;schwarz&lt;/i&gt; sind wie die Nacht und wenn in ihnen &lt;i&gt;schlummernde Macht&lt;/i&gt; glüht!
+      <DefaultText>„Ganz besondere Materialien, seltene Metalle – vor allem wenn sie so &lt;i&gt;schwarz&lt;/i&gt; sind wie die Nacht und wenn in ihnen &lt;i&gt;schlummernde Macht&lt;/i&gt; glüht!“
 
-"Nun, ich vermute, das werde ich wissen, sobald ich es entdeckt habe."
+„Nun, ich vermute, das werde ich wissen, sobald ich es entdeckt habe.“
 
 Sie lächelt gutgelaunt und zuckt mit den Schultern.</DefaultText>
       <FemaleText />
@@ -332,7 +332,7 @@ Sie lächelt gutgelaunt und zuckt mit den Schultern.</DefaultText>
     </Entry>
     <Entry>
       <ID>79</ID>
-      <DefaultText>Hast du noch immer dieses seltsame Etwas, das ich für dich geschmiedet habe? Wenn du irgendwelche seltsamen Metalle gefunden haben, können wir sie damit kombinieren. Du musst es mich nur wissen lassen. Izzia bedeutet dir, frei und offen zu sprechen.</DefaultText>
+      <DefaultText>„Hast du noch immer dieses seltsame Etwas, das ich für dich geschmiedet habe? Wenn du irgendwelche seltsamen Metalle gefunden haben, können wir sie damit kombinieren. Du musst es mich nur wissen lassen.“ Izzia bedeutet dir, frei und offen zu sprechen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -377,7 +377,7 @@ Sie lächelt gutgelaunt und zuckt mit den Schultern.</DefaultText>
     </Entry>
     <Entry>
       <ID>93</ID>
-      <DefaultText>[Ihr Toamowhais Zahn und das Gewicht der Offenbarung geben.] "Schmiede diese beiden Einzelteile zu einem Stück."</DefaultText>
+      <DefaultText>[Ihr den Zahn des Toamowhai und das Gewicht der Offenbarung geben.] „Schmiede diese beiden Einzelteile zu einem Stück.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -422,7 +422,7 @@ Sie lächelt gutgelaunt und zuckt mit den Schultern.</DefaultText>
     </Entry>
     <Entry>
       <ID>102</ID>
-      <DefaultText>Hast du dir den Zeh gestoßen oder so etwas? Einen Augenblick lang war dein Gesicht völlig ausdruckslos. Hier, eine Prise davon tut mir immer richtig gut.</DefaultText>
+      <DefaultText>„Hast du dir den Zeh gestoßen oder so etwas? Einen Augenblick lang war dein Gesicht völlig ausdruckslos. Hier, eine Prise davon tut mir immer richtig gut.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax3_exported/localized/de_patch/text/conversations/lax/lax_cv_shards.stringtable
+++ b/lax3_exported/localized/de_patch/text/conversations/lax/lax_cv_shards.stringtable
@@ -38,9 +38,9 @@ Ein Puls, der nicht der deine ist, pocht in deinen Ohren.</DefaultText>
     </Entry>
     <Entry>
       <ID>7</ID>
-      <DefaultText>Du taumelst als sich wieder Normalität einstellt und fühlst dich ein wenig aus dem Gleichgewicht gebracht. 
+      <DefaultText>Du taumelst, als sich wieder Normalität einstellt, und fühlst dich ein wenig aus dem Gleichgewicht gebracht. 
 
-Du erholst dich schnell. Dann ist der Moment vorbei. </DefaultText>
+Du erholst dich schnell. Dann ist der Moment vorbei.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_00_cv_archmage_critpath.stringtable
+++ b/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_00_cv_archmage_critpath.stringtable
@@ -18,7 +18,7 @@ Llengrath glättet ihre Robe mit ruckartigen, wütenden Bewegungen, dreht ihrem 
     </Entry>
     <Entry>
       <ID>4</ID>
-      <DefaultText>"Du bist ... Du bist zurück! Und ein bisschen mehr lebendig als ich erwartet habe." Tayn sieht dich von oben bis unten an und kaut an seinem Daumennagel.</DefaultText>
+      <DefaultText>„Du bist … Du bist zurück! Und ein bisschen lebendiger als ich erwartet habe.“ Tayn sieht dich von oben bis unten an und kaut an seinem Daumennagel.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -232,7 +232,7 @@ Das Todesfeuer kann keine weitere Katastrophe von Eothas' Ausmaßen ertragen."</
     </Entry>
     <Entry>
       <ID>56</ID>
-      <DefaultText>"Wenn du meint."</DefaultText>
+      <DefaultText>„Wenn du meinst.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -277,9 +277,9 @@ Das Todesfeuer kann keine weitere Katastrophe von Eothas' Ausmaßen ertragen."</
     </Entry>
     <Entry>
       <ID>65</ID>
-      <DefaultText>"Wenn Tayns Annahme korrekt ist, kann es Maura nicht erlaubt werden, ihren Plan durchzuführen.
+      <DefaultText>„Wenn Tayns Annahme korrekt ist, kann es Maura nicht erlaubt werden, ihren Plan durchzuführen.“
 
-"Egal wie altruistisch ihre Motive sein mögen, sie gefährdet uns alle."</DefaultText>
+„Egal wie altruistisch ihre Motive sein mögen, sie gefährdet uns alle.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -396,7 +396,7 @@ Llengrath beugt sich vor, begierig auf Neuigkeiten.</DefaultText>
     </Entry>
     <Entry>
       <ID>100</ID>
-      <DefaultText>Das sagt die Richtige! Für mich ging es &lt;i&gt;immer&lt;/i&gt; um Maura. Die weiteren Vorteile waren nur sekundär. Im besten Fall.</DefaultText>
+      <DefaultText>„Das sagt die Richtige! Für mich ging es &lt;i&gt;immer&lt;/i&gt; um Maura. Die weiteren Vorteile waren nur sekundär. Im besten Fall.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -456,7 +456,7 @@ Llengrath beugt sich vor, begierig auf Neuigkeiten.</DefaultText>
     </Entry>
     <Entry>
       <ID>113</ID>
-      <DefaultText>"Aye, aye, casità." Fassina salutiert schnell und zackig. Ihre finstere Mine wird weicher und verzieht sich zu einem kurzen Lächeln.</DefaultText>
+      <DefaultText>„Aye, aye, casità.“ Fassina salutiert schnell und zackig. Ihre finstere Miene wird weicher und verzieht sich zu einem kurzen Lächeln.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -570,7 +570,7 @@ Llengrath ignoriert ihn beflissentlich.</DefaultText>
     </Entry>
     <Entry>
       <ID>160</ID>
-      <DefaultText>"Es gab als einst &lt;i&gt;elf&lt;/i&gt; riesige Adra-Statuen, die umher liefen?"</DefaultText>
+      <DefaultText>„Es gab also einst &lt;i&gt;elf&lt;/i&gt; riesige Adra-Statuen, die umher liefen?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -620,7 +620,7 @@ Llengrath ignoriert ihn beflissentlich.</DefaultText>
     </Entry>
     <Entry>
       <ID>174</ID>
-      <DefaultText>"Ich kann nicht behaupten, dass ich mich freue zu erfahren, dass du Waels titanenhafte Form ruhen hast lassen. "Du hast das Unvermeidliche nur herausgezögert."</DefaultText>
+      <DefaultText>„Ich kann nicht behaupten, dass ich mich freue zu erfahren, dass du Waels titanenhafte Form ruhen hast lassen. Du hast das Unvermeidliche nur herausgezögert.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -927,16 +927,16 @@ So lange wie ein wild gewordener Magier an diesem Ort herumrennt, ist Eora in gr
     </Entry>
     <Entry>
       <ID>248</ID>
-      <DefaultText>"Die Imps berichten, dass du mit einer gewissen pilzigen Bedrohung in den Archiven übereingekommen bist.
+      <DefaultText>„Die Imps berichten, dass du mit einer gewissen pilzigen Bedrohung in den Archiven übereingekommen bist.“
 
-"Es braucht schon eine... einzigartige Seele, um mit einem Pilz zu verhandeln. Beeindruckend."</DefaultText>
+„Es braucht schon eine… einzigartige Seele, um mit einem Pilz zu verhandeln. Beeindruckend.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>249</ID>
-      <DefaultText>"Die Imps berichten, dass du dich um die Pilz-Infektion in den Archiven gekümmert hast.
+      <DefaultText>„Die Imps berichten, dass du dich um die Pilz-Infektion in den Archiven gekümmert hast.“
 
-"Eine Sorge weniger, die mir durch den Kopf geht. Gute Arbeit."</DefaultText>
+„Eine Sorge weniger, die mir durch den Kopf geht. Gute Arbeit.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1036,7 +1036,7 @@ So lange wie ein wild gewordener Magier an diesem Ort herumrennt, ist Eora in gr
     </Entry>
     <Entry>
       <ID>275</ID>
-      <DefaultText>"Du wärst besser damit gedient, einen Imp zu sagen, dass er laufen und nicht fliegen soll."
+      <DefaultText>„Dir wäre besser damit gedient, einem Imp zu sagen, dass er laufen und nicht fliegen soll.“
 
 Mit langsamen schlagenden Flügeln blicken die Imps angesichts dieses Vorschlages finster vor sich hin.</DefaultText>
       <FemaleText />
@@ -1068,7 +1068,7 @@ Mit langsamen schlagenden Flügeln blicken die Imps angesichts dieses Vorschlage
     </Entry>
     <Entry>
       <ID>284</ID>
-      <DefaultText>"Diese Tentakel wachsen, bis sie jede Insel im Todesfeuer verschlungen haben und wir alle gedankenlose Leibeigene in einem nicht enden wollenden Tentakel-Alptraum geworden sind."</DefaultText>
+      <DefaultText>„Diese Tentakel wachsen, bis sie jede Insel im Todesfeuer verschlungen haben und wir alle gedankenlose Leibeigene in einem nicht enden wollenden Tentakel-Albtraum geworden sind.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1158,7 +1158,7 @@ Mit langsamen schlagenden Flügeln blicken die Imps angesichts dieses Vorschlage
     </Entry>
     <Entry>
       <ID>309</ID>
-      <DefaultText>"Das nächste Mal, wenn ein Gott dich bittet, eine Eingeweidenkonstruktion von einer Verstopfung zu befreien, sage ihm, dass ich beschäftigt bin."</DefaultText>
+      <DefaultText>„Das nächste Mal, wenn ein Gott dich bittet, eine Eingeweidekonstruktion von einer Verstopfung zu befreien, sage ihm, dass ich beschäftigt bin.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1255,8 +1255,8 @@ Llengrath richtet sich zu ihrer vollen Größe auf und macht eine etwas offiziel
     </Entry>
     <Entry>
       <ID>331</ID>
-      <DefaultText>Ach, bei Hel, Wächter. Willst du mich dazu bringen, vor unseren neuen Freunden rot zu werden?</DefaultText>
-      <FemaleText>Ach, bei Hel, Wächterin. Willst du mich dazu bringen, vor unseren neuen Freunden rot zu werden?</FemaleText>
+      <DefaultText>„Ach, bei Hel, Wächter. Willst du mich dazu bringen, vor unseren neuen Freunden rot zu werden?“</DefaultText>
+      <FemaleText>„Ach, bei Hel, Wächterin. Willst du mich dazu bringen, vor unseren neuen Freunden rot zu werden?“</FemaleText>
     </Entry>
     <Entry>
       <ID>332</ID>
@@ -1275,7 +1275,7 @@ Llengrath richtet sich zu ihrer vollen Größe auf und macht eine etwas offiziel
     </Entry>
     <Entry>
       <ID>335</ID>
-      <DefaultText>Wenigstens einer von uns hat Spaß. Ich kann mir keinen intelligenten Gestandenen vorstellen, der die Macht über Waels Körper verdient hat, er kann also ebenso gut an einen intelligenten Pilz übergehen.</DefaultText>
+      <DefaultText>„Wenigstens einer von uns hat Spaß. Ich kann mir keinen intelligenten Gestandenen vorstellen, der die Macht über Waels Körper verdient hat, er kann also ebenso gut an einen intelligenten Pilz übergehen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1285,12 +1285,12 @@ Llengrath richtet sich zu ihrer vollen Größe auf und macht eine etwas offiziel
     </Entry>
     <Entry>
       <ID>337</ID>
-      <DefaultText>Es ist sicherer, wenn wir ihn nicht mehr haben. Wir würden uns nur selbst zerstören.</DefaultText>
+      <DefaultText>„Es ist sicherer, wenn wir ihn nicht mehr haben. Wir würden uns nur selbst zerstören.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>338</ID>
-      <DefaultText>"Möge unser pilziger Freund die natürliche Schönheit des Todesfeuer wieder herstellen."</DefaultText>
+      <DefaultText>„Möge unser pilziger Freund die natürliche Schönheit des Todesfeuers wieder herstellen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1315,12 +1315,12 @@ Llengrath richtet sich zu ihrer vollen Größe auf und macht eine etwas offiziel
     </Entry>
     <Entry>
       <ID>343</ID>
-      <DefaultText>Eothas hat Konkurrenz. Das ist was zählt.</DefaultText>
+      <DefaultText>„Eothas hat Konkurrenz. Das ist was zählt.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>344</ID>
-      <DefaultText>"Jetzt haben die Mächte des Todesfeuer zwei Gründe, um zusammen zu arbeiten."</DefaultText>
+      <DefaultText>„Jetzt haben die Mächte des Todesfeuers zwei Gründe, um zusammen zu arbeiten.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1472,7 +1472,7 @@ Mit finsterer Miene stößt sie einen verirrten Tentakel zur Seite, der versucht
     </Entry>
     <Entry>
       <ID>379</ID>
-      <DefaultText>Ah... das tut mir leid. Ich komme endlich dazu, darüber nachzudenken, wie viel Zeit wir sparen, wenn wir ab und zu ein paar Silben auslassen. Aber hier verschwende ich nur meine Worte. Tayn räuspert sich und wendet den Blick ab.</DefaultText>
+      <DefaultText>„Ah… das tut mir leid. Ich komme endlich dazu, darüber nachzudenken, wie viel Zeit wir sparen, wenn wir ab und zu ein paar Silben auslassen. Aber hier verschwende ich nur meine Worte.“ Tayn räuspert sich und wendet den Blick ab.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1509,7 +1509,7 @@ Tayn reibt sich voller Freude die Hände, als er eine Masse von Augen und Tentak
     </Entry>
     <Entry>
       <ID>393</ID>
-      <DefaultText>Wenn du mit der Suche in einem der Flügel beginnst, durchwühlen wir diesen Bereich nach weiteren Informationen. Sie nickt und wendet sich ab.</DefaultText>
+      <DefaultText>„Wenn du mit der Suche in einem der Flügel beginnst, durchwühlen wir diesen Bereich nach weiteren Informationen.“ Sie nickt und wendet sich ab.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1554,7 +1554,7 @@ Tayn reibt sich voller Freude die Hände, als er eine Masse von Augen und Tentak
     </Entry>
     <Entry>
       <ID>407</ID>
-      <DefaultText>Ich würde nur ungern das sehen, was er als das &lt;i&gt;gute&lt;/i&gt; Ergebnis bezeichnet hat.</DefaultText>
+      <DefaultText>„Ich würde nur ungern das sehen, was er als das &lt;i&gt;gute&lt;/i&gt; Ergebnis bezeichnet hat.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1564,9 +1564,9 @@ Tayn reibt sich voller Freude die Hände, als er eine Masse von Augen und Tentak
     </Entry>
     <Entry>
       <ID>409</ID>
-      <DefaultText>"Stille. Wunderhübsche Stille. Waels titanhafte Form ist tot und das ist dein Werk. Wir müssen nicht länger welche Zerstörung auch immer fürchten, die sie über Eora niedergehen lassen könnte.
+      <DefaultText>„Stille. Wunderhübsche Stille. Waels titanhafte Form ist tot und das ist dein Werk. Wir müssen nicht länger welche Zerstörung auch immer fürchten, die sie über Eora niedergehen lassen könnte.“
 
-"Gute Arbeit."</DefaultText>
+„Gute Arbeit.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1607,9 +1607,9 @@ Llengrath neigt dankend den Kopf in deine Richtung und nickt dir zum Abschied zu
     </Entry>
     <Entry>
       <ID>418</ID>
-      <DefaultText>"Wenn ich dich im nächsten Lebe sehe, ist das schon zu bald.
+      <DefaultText>„Wenn ich dich im nächsten Lebe sehe, ist das schon zu bald.“
 
-"Auf Wiedersehen."
+„Auf Wiedersehen.“
 
 Llengrath geht ohne ein weiteres Wort.</DefaultText>
       <FemaleText />
@@ -1756,14 +1756,14 @@ Llengrath geht ohne ein weiteres Wort.</DefaultText>
     </Entry>
     <Entry>
       <ID>454</ID>
-      <DefaultText>"In Ordnung, du hast mich erwischt. Ich habe eine Spur kandierter Nüsse gefunden, die hinunter zu der Sammlung fühlte und ich wollte nicht gerne teilen."</DefaultText>
+      <DefaultText>„In Ordnung, du hast mich erwischt. Ich habe eine Spur kandierter Nüsse gefunden, die hinunter zu der Sammlung führte und ich wollte nicht gerne teilen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>467</ID>
-      <DefaultText>"Der Zirkel verbirgt viel vor den Einwohnern Eoras und nennt es Altruismus.
+      <DefaultText>„Der Zirkel verbirgt viel vor den Einwohnern Eoras und nennt es Altruismus.“
 
-"Ich frage mich, ob wir nicht einen Fehler gemacht haben."</DefaultText>
+„Ich frage mich, ob wir nicht einen Fehler gemacht haben.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1773,7 +1773,7 @@ Llengrath geht ohne ein weiteres Wort.</DefaultText>
     </Entry>
     <Entry>
       <ID>469</ID>
-      <DefaultText>"Außer meine Geheimnisse. Und meine Träume. Niemand sollte je davon erfahren."</DefaultText>
+      <DefaultText>„Außer meinen Geheimnissen. Und meinen Träumen. Niemand sollte je davon erfahren.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1850,7 +1850,7 @@ Er schlägt Tayns prüfenden Finger beiseite.</DefaultText>
     </Entry>
     <Entry>
       <ID>485</ID>
-      <DefaultText>"Ich bin Fassina, Lehrling des Erzmagiers Arkemyr. Der Bastard. Er hat mich voraus geschickt, damit ich seine Augen und Ohren bin.</DefaultText>
+      <DefaultText>„Ich bin Fassina, Lehrling des Erzmagiers Arkemyr. Der Bastard. Er hat mich voraus geschickt, damit ich seine Augen und Ohren bin.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1885,7 +1885,7 @@ Er schlägt Tayns prüfenden Finger beiseite.</DefaultText>
     </Entry>
     <Entry>
       <ID>493</ID>
-      <DefaultText>"Was, Junge? Gibt nichts hinzufügen zu machtvollen Körpern der Göttern, oder?"</DefaultText>
+      <DefaultText>„Was, Junge? Gibt nichts hinzuzufügen zu machtvollen Körpern der Götter, oder?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1995,7 +1995,7 @@ Er schlägt Tayns prüfenden Finger beiseite.</DefaultText>
     </Entry>
     <Entry>
       <ID>520</ID>
-      <DefaultText>"Weißt du was? Achte nicht auf mein Geschwafel. Wenn du es auf einem Pergament geschrieben hast, dann bin ich &lt;i&gt;sicher&lt;/i&gt;, dass deine Erzählung wahr ist." Tayn klopft dir auf die Schulter, sein typisches Grinsen sieht eher angestrengt denn fröhlich aus.</DefaultText>
+      <DefaultText>„Weißt du was? Achte nicht auf mein Geschwafel. Wenn du es auf ein Pergament geschrieben hast, dann bin ich &lt;i&gt;sicher&lt;/i&gt;, dass deine Erzählung wahr ist.“ Tayn klopft dir auf die Schulter, sein typisches Grinsen sieht eher angestrengt denn fröhlich aus.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -2177,12 +2177,12 @@ Nachdem der Angriff von Waels Stimme langsam verstummt, senkt Llengrath langsam 
     </Entry>
     <Entry>
       <ID>561</ID>
-      <DefaultText>Die Luft hat sich geändert. Es riecht nach ... Blut. Blut und Verfall. Was ist in Waels Körper geschehen?</DefaultText>
+      <DefaultText>„Die Luft hat sich geändert. Es riecht nach … Blut. Blut und Verfall. Was ist in Waels Körper geschehen?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>562</ID>
-      <DefaultText>Bevor du eine Antwort hervorbringen kannst, beginnt das Skriptorium dumpf zu vibrieren. Bücher fallen von den Regalen und stürzen im freien Fall in den Abgrund darunter stürzen.</DefaultText>
+      <DefaultText>Bevor du eine Antwort hervorbringen kannst, beginnt das Skriptorium dumpf zu vibrieren. Bücher fallen von den Regalen und stürzen im freien Fall in den Abgrund darunter.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -2211,12 +2211,12 @@ Als die mentale Vorstellung der Sporenkolonie langsam aus euren Gedächtnissen v
     </Entry>
     <Entry>
       <ID>567</ID>
-      <DefaultText>Bevor du eine Antwort hervorbringen kannst, beginnt das Skriptorium dumpf zu vibrieren. Bücher fallen von den Regalen und stürzen im freien Fall in den Abgrund darunter stürzen.</DefaultText>
+      <DefaultText>Bevor du eine Antwort hervorbringen kannst, beginnt das Skriptorium dumpf zu vibrieren. Bücher fallen von den Regalen und stürzen im freien Fall in den Abgrund darunter.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>568</ID>
-      <DefaultText>"Ich bin der Tod der Hoffnung. Bald werden der Zirkel, das Archipel und ganz Eora wissen, dass &lt;i&gt;Concelhaut&lt;/i&gt; der einzige Gott ist, der eurer Furcht würdig ist."</DefaultText>
+      <DefaultText>„Ich bin der Tod der Hoffnung. Bald werden der Zirkel, der Archipel und ganz Eora wissen, dass &lt;i&gt;Concelhaut&lt;/i&gt; der einzige Gott ist, der eurer Furcht würdig ist.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_00_cv_bekarna.stringtable
+++ b/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_00_cv_bekarna.stringtable
@@ -51,7 +51,7 @@
     </Entry>
     <Entry>
       <ID>12</ID>
-      <DefaultText>"Ich habe es nicht aus reiner Wohltat getan, weißt du?"</DefaultText>
+      <DefaultText>„Ich habe es nicht aus reiner Wohltätigkeit getan, weißt du?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -106,7 +106,7 @@
     </Entry>
     <Entry>
       <ID>24</ID>
-      <DefaultText>"Ich habe dich aus tödlicher Gefahr gerettet und du bietest nichts außer Getränke im Gegenzug?"</DefaultText>
+      <DefaultText>„Ich habe dich aus tödlicher Gefahr gerettet und du bietest nichts als Getränke im Gegenzug?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -156,7 +156,7 @@
     </Entry>
     <Entry>
       <ID>34</ID>
-      <DefaultText>"Natürlich habe ich deine Bezahlung in Angriff genommen. Der Gesichtslose hat mir alles gestohlen &lt;i&gt;außer&lt;/i&gt; meinen Beutel." </DefaultText>
+      <DefaultText>„Natürlich habe ich deine Bezahlung in Angriff genommen. Die Gesichtslosen haben mir alles gestohlen &lt;i&gt;außer&lt;/i&gt; meinem Beutel.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -236,7 +236,7 @@
     </Entry>
     <Entry>
       <ID>57</ID>
-      <DefaultText>Ich mache mich dann auf den Weg. Glückwunsch, Bekarna.</DefaultText>
+      <DefaultText>„Ich mache mich dann auf den Weg. Glückwunsch, Bekarna.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -261,7 +261,7 @@
     </Entry>
     <Entry>
       <ID>66</ID>
-      <DefaultText>[Ihr einen Saphir geben.] "Hier. Ich habe das für ich gefangen."</DefaultText>
+      <DefaultText>[Ihr einen Saphir geben.] „Hier. Ich habe das für dich gefangen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -340,7 +340,7 @@ Dann schüttelt sie ihren Kopf und gibt dir sanftmütig als Gegenleistung etwas 
     </Entry>
     <Entry>
       <ID>83</ID>
-      <DefaultText>"Die Sterne sind alle da oben &lt;i&gt;falsch&lt;/i&gt;. Ich muss das wieder gerade biegen."</DefaultText>
+      <DefaultText>„Die Sterne sind alle &lt;i&gt;falsch&lt;/i&gt; da oben. Ich muss das wieder gerade biegen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -355,7 +355,7 @@ Dann schüttelt sie ihren Kopf und gibt dir sanftmütig als Gegenleistung etwas 
     </Entry>
     <Entry>
       <ID>86</ID>
-      <DefaultText>&lt;i&gt;Sterne.&lt;/i&gt; Siehst du sie nicht? Ich sehe sie, aber sie sind alle in der falschen Reihenfolge.</DefaultText>
+      <DefaultText>„&lt;i&gt;Sterne.&lt;/i&gt; Siehst du sie nicht? Ich sehe sie, aber sie sind alle in der falschen Reihenfolge.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -565,9 +565,9 @@ Dann schüttelt sie ihren Kopf und gibt dir sanftmütig als Gegenleistung etwas 
     </Entry>
     <Entry>
       <ID>135</ID>
-      <DefaultText>"Über mich musst du dir keine Sorgen machen. Selbst wenn ich mich nicht an dein Gesicht erinnere, so gibt es doch einen Ort in meinem Gedächtnis, an dem die &lt;i&gt;Idee&lt;/i&gt; von dir fortbesteht.
+      <DefaultText>„Über mich musst du dir keine Sorgen machen. Selbst wenn ich mich nicht an dein Gesicht erinnere, so gibt es doch einen Ort in meinem Gedächtnis, an dem die &lt;i&gt;Idee&lt;/i&gt; von dir fortbesteht.“
 
-"Falls ... falls das einen Sinn ergibt." </DefaultText>
+„Falls … falls das einen Sinn ergibt.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -607,12 +607,12 @@ Dann schüttelt sie ihren Kopf und gibt dir sanftmütig als Gegenleistung etwas 
     </Entry>
     <Entry>
       <ID>143</ID>
-      <DefaultText>"Die Sterne können mir helfen. Die Sterne sind ... Stabilität? Ideen, die in Muster organisiert sind. Vorhersehbar, beruhigend." Sie runzelt die Stirn, während sie sich anstrengt, die richtigen Worte zu finden. </DefaultText>
+      <DefaultText>„Die Sterne können mir helfen. Die Sterne sind … Stabilität? Ideen, die in Mustern organisiert sind. Vorhersehbar, beruhigend.“ Sie runzelt die Stirn, während sie sich anstrengt, die richtigen Worte zu finden. </DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>144</ID>
-      <DefaultText>"Wenn du die Sterne finden kannst, dann kannst du auch mich finden."“</DefaultText>
+      <DefaultText>„Wenn du die Sterne finden kannst, dann kannst du auch mich finden.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -622,12 +622,12 @@ Dann schüttelt sie ihren Kopf und gibt dir sanftmütig als Gegenleistung etwas 
     </Entry>
     <Entry>
       <ID>147</ID>
-      <DefaultText>Wenn du einen Zauber schreibst, wirst du dadurch dann zu einer Erzmagierin?"</DefaultText>
+      <DefaultText>„Wenn du einen Zauber schreibst, wirst du dadurch dann zu einer Erzmagierin?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>151</ID>
-      <DefaultText>"So wie ich den Zirkel kenne, wird das nicht einfach werden. Das könnte Jahre dauern. Selbst Concelhaut musst darum kämpfen, aufgenommen zu werden.“</DefaultText>
+      <DefaultText>„So wie ich den Zirkel kenne, wird das nicht einfach werden. Das könnte Jahre dauern. Selbst Concelhaut musste darum kämpfen, aufgenommen zu werden.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -652,7 +652,7 @@ Dann schüttelt sie ihren Kopf und gibt dir sanftmütig als Gegenleistung etwas 
     </Entry>
     <Entry>
       <ID>157</ID>
-      <DefaultText>"Die Verschleierten Hallen sind wie eine Elster auf der Suche nach glänzenden Dingen. Es ist am wahrscheinlichsten, hier einen himmlischen Auslöser zu finden als an irgendeinem anderen Ort im Archipel."</DefaultText>
+      <DefaultText>„Die Verschleierten Hallen sind wie eine Elster auf der Suche nach glänzenden Dingen. Es ist wahrscheinlicher, hier einen himmlischen Auslöser zu finden als an irgendeinem anderen Ort im Archipel.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -712,7 +712,7 @@ Dann schüttelt sie ihren Kopf und gibt dir sanftmütig als Gegenleistung etwas 
     </Entry>
     <Entry>
       <ID>169</ID>
-      <DefaultText>"Sie glaubt, sie könne die Macht aus einer Sternschnuppe ziehen. Dummheit, reine Zeitverschwendung. Aber ich muss ihren Ehrgeiz zu bewundern. Ich habe schon immer angenommen, dass etwas in der Art über mir stand." Fassina wendet sich ab und verschränkt die Arme. </DefaultText>
+      <DefaultText>„Sie glaubt, sie könne die Macht aus einer Sternschnuppe ziehen. Dummheit, reine Zeitverschwendung. Aber ich muss ihren Ehrgeiz bewundern. Ich habe schon immer angenommen, dass etwas in der Art über mir stand.“ Fassina wendet sich ab und verschränkt die Arme. </DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -852,7 +852,7 @@ Dann schüttelt sie ihren Kopf und gibt dir sanftmütig als Gegenleistung etwas 
     </Entry>
     <Entry>
       <ID>204</ID>
-      <DefaultText>"Ich habe das ein oder andere Buch gelesen, mit denen ich lieber einen Abend verbringen würde als mit den meisten Menschen." Xoti nickt.</DefaultText>
+      <DefaultText>„Ich habe das ein oder andere Buch gelesen, mit dem ich lieber einen Abend verbringen würde als mit den meisten Menschen.“ Xoti nickt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -872,7 +872,7 @@ Dann schüttelt sie ihren Kopf und gibt dir sanftmütig als Gegenleistung etwas 
     </Entry>
     <Entry>
       <ID>209</ID>
-      <DefaultText>"Ich fass das Zeug nicht an. Davon bekomme ich nur Alpträume." </DefaultText>
+      <DefaultText>„Ich fass das Zeug nicht an. Davon bekomme ich nur Albträume.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -912,7 +912,7 @@ Dann schüttelt sie ihren Kopf und gibt dir sanftmütig als Gegenleistung etwas 
     </Entry>
     <Entry>
       <ID>218</ID>
-      <DefaultText>"Ich habe eine Sternschnuppe im Himmel über den Schwarzen Insel beobachtet. So schimmernd und hell! Ich habe Söldner ausgesandt, um danach zu suchen, habe aber einige Zeit lang nichts mehr von ihnen gehört."</DefaultText>
+      <DefaultText>„Ich habe eine Sternschnuppe im Himmel über den Schwarzen Inseln beobachtet. So schimmernd und hell! Ich habe Söldner ausgesandt, um danach zu suchen, habe aber einige Zeit lang nichts mehr von ihnen gehört.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1199,7 +1199,7 @@ Dann schüttelt sie ihren Kopf und gibt dir sanftmütig als Gegenleistung etwas 
     </Entry>
     <Entry>
       <ID>284</ID>
-      <DefaultText>"Und riskiere, zurück in meine Behausung in der Sammlung zurückgezerrt zu werden? Einige von uns sind nicht ausgerüstet, um gegen Abscheulichkeiten mit Tentakeln zu kämpfen." Sie mustert dich von oben bis unten. </DefaultText>
+      <DefaultText>„Und riskiere, zurück in meine Behausung in der Sammlung gezerrt zu werden? Einige von uns sind nicht ausgerüstet, um gegen Abscheulichkeiten mit Tentakeln zu kämpfen.“ Sie mustert dich von oben bis unten. </DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1309,12 +1309,12 @@ Dann schüttelt sie ihren Kopf und gibt dir sanftmütig als Gegenleistung etwas 
     </Entry>
     <Entry>
       <ID>312</ID>
-      <DefaultText>"Du ... du kennst mich? Ich kenn mich nicht einmal selbst."</DefaultText>
+      <DefaultText>„Du ... du kennst mich? Ich kenne mich nicht einmal selbst.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>313</ID>
-      <DefaultText>"Die Sterne sind alle da oben &lt;i&gt;falsch&lt;/i&gt;. Ich muss das wieder gerade biegen."</DefaultText>
+      <DefaultText>„Die Sterne sind alle &lt;i&gt;falsch&lt;/i&gt; da oben. Ich muss das wieder gerade biegen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_00_cv_fassina_minihub.stringtable
+++ b/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_00_cv_fassina_minihub.stringtable
@@ -61,7 +61,7 @@
     </Entry>
     <Entry>
       <ID>14</ID>
-      <DefaultText>"Auf jeden Fall bin ich nun frei, um die Welt zu studieren, und all das Dank dir. Daher werde ich es jetzt sagen – agracima."</DefaultText>
+      <DefaultText>„Auf jeden Fall bin ich nun frei, um die Welt zu studieren, und all das dank dir. Daher werde ich es jetzt sagen – agracima.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -206,7 +206,7 @@
     </Entry>
     <Entry>
       <ID>60</ID>
-      <DefaultText>"Casità, ich schwöre ..." Fassina kneift sich in die Nasenbrücke und seufzt laut.</DefaultText>
+      <DefaultText>„Casità, ich schwöre …“ Fassina kneift sich in den Nasenrücken und seufzt laut.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -381,7 +381,7 @@
     </Entry>
     <Entry>
       <ID>132</ID>
-      <DefaultText>Eine solche Ungewissheit. Ich nehme aber an, dass es das langfristig wert ist, oder?"</DefaultText>
+      <DefaultText>„Eine solche Ungewissheit. Ich nehme aber an, dass es das langfristig wert ist, oder?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -591,7 +591,7 @@
     </Entry>
     <Entry>
       <ID>216</ID>
-      <DefaultText>"Da Waels Körper nun tot ist, sind wir einen schlafenden Tentakel-Gott los geworden. Du hast eindeutig deine Lektion bei Caed Nua gelernt" </DefaultText>
+      <DefaultText>„Da Waels Körper nun tot ist, sind wir einen schlafenden Tentakel-Gott los geworden. Du hast eindeutig deine Lektion bei Caed Nua gelernt.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -681,7 +681,7 @@
     </Entry>
     <Entry>
       <ID>258</ID>
-      <DefaultText>"Wir sind nicht hier, um uns gegenseitig mit leeren Gefälligkeiten zu erfreuen. Wenn ich mich nicht irre, musst du einen Gott fangen, Handelsgesellschaften gegeneinander aufbringen und ein Archipel befrieden. Nur kein Druck, casità." </DefaultText>
+      <DefaultText>„Wir sind nicht hier, um uns gegenseitig mit leeren Gefälligkeiten zu erfreuen. Wenn ich mich nicht irre, musst du einen Gott fangen, Handelsgesellschaften gegeneinander aufbringen und einen Archipel befrieden. Nur kein Druck, casità.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -726,7 +726,7 @@
     </Entry>
     <Entry>
       <ID>268</ID>
-      <DefaultText>"Im Rahmen unserer Bekanntschaft lehrte mich Konstanten ... etwas Schönes, das ich so schnell nicht vergessen werde." Fassina beißt sich auf den Fingernagel und wendet den Blick an.</DefaultText>
+      <DefaultText>„Im Rahmen unserer Bekanntschaft lehrte mich Konstanten … etwas Schönes, das ich so schnell nicht vergessen werde.“ Fassina beißt sich auf den Fingernagel und wendet den Blick ab.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -761,7 +761,7 @@
     </Entry>
     <Entry>
       <ID>276</ID>
-      <DefaultText>"Ich kam als unterwürfiger Lehrling zum Archipel. Eines Tages hoffe ich, es mit etwas mehr Würde wieder verlassen zu können."</DefaultText>
+      <DefaultText>„Ich kam als unterwürfiger Lehrling zum Archipel. Eines Tages hoffe ich, ihn mit etwas mehr Würde wieder verlassen zu können.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -796,7 +796,7 @@
     </Entry>
     <Entry>
       <ID>286</ID>
-      <DefaultText>"Als wir in Neketaka anlegten, stellte er mich als sein Lehrling vor und setzte mich für ein Leben des geistlichen Frondienstes im Schrank ein. Den Rest kennst du ja." </DefaultText>
+      <DefaultText>„Als wir in Neketaka anlegten, stellte er mich als seinen Lehrling vor und setzte mich für ein Leben des geistlichen Frondienstes im Schrank ein. Den Rest kennst du ja.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -861,7 +861,7 @@
     </Entry>
     <Entry>
       <ID>301</ID>
-      <DefaultText>"Als ich diesen Weg einschlug, entdeckte ich schnell, dass sich bei Magie alles um Grammatik, Präzision und unerträglichen Regeln dreht." </DefaultText>
+      <DefaultText>„Als ich diesen Weg einschlug, entdeckte ich schnell, dass sich bei Magie alles um Grammatik, Präzision und unerträgliche Regeln dreht.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -996,7 +996,7 @@
     </Entry>
     <Entry>
       <ID>331</ID>
-      <DefaultText>"Aye, aye, casità." Fassina salutiert schnell und zackig. Ihre finstere Mine wird weicher und verzieht sich zu einem kurzen Lächeln.</DefaultText>
+      <DefaultText>„Aye, aye, casità.“ Fassina salutiert schnell und zackig. Ihre finstere Miene wird weicher und verzieht sich zu einem kurzen Lächeln.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1021,7 +1021,7 @@
     </Entry>
     <Entry>
       <ID>336</ID>
-      <DefaultText>"Niemand im Zirkel traute ihr, was das Archipel anging." </DefaultText>
+      <DefaultText>„Niemand im Zirkel traute ihr, was den Archipel anging.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_00_cv_innkeeper_imp.stringtable
+++ b/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_00_cv_innkeeper_imp.stringtable
@@ -181,7 +181,7 @@
     </Entry>
     <Entry>
       <ID>40</ID>
-      <DefaultText>"ZAUBERER LÜGEN. ZAUBERERER &lt;i&gt;SCHLIMMSTE&lt;/i&gt; PERSONEN. ABER SCHLÄFRIGES ERBROCHENES RICHTET ALLES, JA? HILFT DIR ZU ENTSPANNEN."
+      <DefaultText>„ZAUBERER LÜGEN. ZAUBERER &lt;i&gt;SCHLIMMSTE&lt;/i&gt; PERSONEN. ABER SCHLÄFRIGES ERBROCHENES RICHTET ALLES, JA? HILFT DIR ZU ENTSPANNEN.“
 
 Zwinkernd zeigt der Imp auf eine Sammlung veredelter Kräuter und Narkotika. </DefaultText>
       <FemaleText />
@@ -355,7 +355,7 @@ Die Finger bewegen sich. Sie &lt;i&gt;bewegen sich.&lt;/i&gt; Wenn. Du. Es. Ihne
     </Entry>
     <Entry>
       <ID>77</ID>
-      <DefaultText>"HE! LEBST DU NOCH?" Deine Sicht wird klarer als Schläfriges Erbrochenes dir gegen deine Stirn schnalzt.</DefaultText>
+      <DefaultText>„HE! LEBST DU NOCH?“ Deine Sicht wird klarer, als Schläfriges Erbrochenes dir gegen deine Stirn schnalzt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -380,7 +380,7 @@ Die Finger bewegen sich. Sie &lt;i&gt;bewegen sich.&lt;/i&gt; Wenn. Du. Es. Ihne
     </Entry>
     <Entry>
       <ID>85</ID>
-      <DefaultText>Zeit verstreicht. Du fragst dich, ob Eothas ein so großes Schloss bauen kann, das nicht einmal er umwerfen könnte.</DefaultText>
+      <DefaultText>Zeit verstreicht. Du fragst dich, ob Eothas ein so großes Schloss bauen könnte, das nicht einmal er es umwerfen könnte.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -410,7 +410,7 @@ Die Finger bewegen sich. Sie &lt;i&gt;bewegen sich.&lt;/i&gt; Wenn. Du. Es. Ihne
     </Entry>
     <Entry>
       <ID>92</ID>
-      <DefaultText>"WENN ES ZEIT IST, SIND NEMNOKS ALLERLIEBSTEN VERBÜNDETE BEREIT." Schläfriges Erbrochenes senkt den Kopf und seufzt ehrfürchtig.</DefaultText>
+      <DefaultText>„WENN ES ZEIT IST, SIND NEMNOKS ALLERLIEBSTE VERBÜNDETE BEREIT.“ Schläfriges Erbrochenes senkt den Kopf und seufzt ehrfürchtig.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_00_cv_vendor_imp.stringtable
+++ b/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_00_cv_vendor_imp.stringtable
@@ -108,7 +108,7 @@ Und zwinkert dir zu. </DefaultText>
     </Entry>
     <Entry>
       <ID>39</ID>
-      <DefaultText>"Ich soll dafür sorgen, dass es kein zweites Eothas gibt."</DefaultText>
+      <DefaultText>„Ich soll dafür sorgen, dass es keinen zweiten Eothas gibt.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -153,12 +153,12 @@ Und zwinkert dir zu. </DefaultText>
     </Entry>
     <Entry>
       <ID>48</ID>
-      <DefaultText>"HE! DUMME UNDANKBARE FASSINA VERDIENT ES NICHT, DEN NACHTTOPF DES MEISTERS  ZU PUTZEN." </DefaultText>
+      <DefaultText>„HE! DUMME UNDANKBARE FASSINA VERDIENT ES NICHT, DEN NACHTTOPF DES MEISTERS ZU PUTZEN.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>49</ID>
-      <DefaultText>"HE! DU SCHLIMME PERSON."  Schmutziges Spray schleicht sich von dir weg.</DefaultText>
+      <DefaultText>„HE! DU SCHLIMME PERSON.“ Schmutziges Spray schleicht sich von dir weg.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -353,7 +353,7 @@ Und zwinkert dir zu. </DefaultText>
     </Entry>
     <Entry>
       <ID>126</ID>
-      <DefaultText>"KANN NICHT LESEN, DUMMER BODENSTINKER. SCHON VERGESSEN? HE! SCHON VERGESSEN? Der Imp versucht mit beiden Klauen das Buch zu zerreißen, schafft es aber nur, den Einband zu verbiegen. </DefaultText>
+      <DefaultText>„KANN NICHT LESEN, DUMMER BODENSTINKER. SCHON VERGESSEN? HE! SCHON VERGESSEN?“ Der Imp versucht mit beiden Klauen das Buch zu zerreißen, schafft es aber nur, den Einband zu verbiegen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -363,7 +363,7 @@ Und zwinkert dir zu. </DefaultText>
     </Entry>
     <Entry>
       <ID>128</ID>
-      <DefaultText>"WILLST DU IMP SPRAY? DU WILLST ES SO SEHR, WAS? HIER. SAMMLE ES." Der Imp wirft dir eine leere Flasche zu und hebt langsam seinen linken Fuß über seinen Kopf. </DefaultText>
+      <DefaultText>„WILLST DU IMP-SPRAY? DU WILLST ES SO SEHR, WAS? HIER. SAMMLE ES.“ Der Imp wirft dir eine leere Flasche zu und hebt langsam seinen linken Fuß über seinen Kopf.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -378,7 +378,7 @@ Und zwinkert dir zu. </DefaultText>
     </Entry>
     <Entry>
       <ID>131</ID>
-      <DefaultText>Du zielst auf den Flaschenrand gerade noch rechtzeitig, um einen Ausstoß von heißer Imp-Ausdünstung abzufangen. Es riecht nach verfaulten Eiern und Lampenöl mit einem Schuss Zimt. Glücklicherweise verpasst es dein Gesicht, aber eine dünne Schicht bedeckt alles andere. Du fühlst dich feucht und unwohl. 
+      <DefaultText>Du zielst gerade noch rechtzeitig auf den Flaschenrand, um einen Ausstoß von heißer Imp-Ausdünstung abzufangen. Es riecht nach verfaulten Eiern und Lampenöl mit einem Schuss Zimt. Glücklicherweise verpasst es dein Gesicht, aber eine dünne Schicht bedeckt alles andere. Du fühlst dich feucht und unwohl. 
 
 Stinkendes Spray schaut dich mit einem ausgelassenen Grinsen an.</DefaultText>
       <FemaleText />

--- a/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_00_si_cataclysm.stringtable
+++ b/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_00_si_cataclysm.stringtable
@@ -122,7 +122,7 @@ Serafen lacht leise. "Der Knabe darf sich aber gerne an meinen Zwiebeln vergreif
     </Entry>
     <Entry>
       <ID>24</ID>
-      <DefaultText>"Maul halten, ihr skorbutkranken Seebären und bewegt eure Ärsche wieder an die Arbeit!"</DefaultText>
+      <DefaultText>„Maul halten, ihr skorbutkranken Seebären, und bewegt eure Ärsche wieder an die Arbeit!“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -166,7 +166,7 @@ Die wenigen Unterhaltungen auf den Decks verstummen nun.</DefaultText>
     </Entry>
     <Entry>
       <ID>33</ID>
-      <DefaultText>Eine lange, graue Linie erstreckt sich über den Horizont. Es scheint zu flimmern, wie die Luft an einem heißen Tag.</DefaultText>
+      <DefaultText>Eine lange, graue Linie erstreckt sich über den Horizont. Sie scheint zu flimmern, wie die Luft an einem heißen Tag.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -286,7 +286,7 @@ Ob das Schiff nun durch die Welle bricht oder die Welle über dem Schiff zusamme
     </Entry>
     <Entry>
       <ID>56</ID>
-      <DefaultText>Die [Player Ship] ächzt als sie die Wellen kreuzt.</DefaultText>
+      <DefaultText>Die [Player Ship] ächzt, als sie die Wellen kreuzt.</DefaultText>
       <FemaleText />
     </Entry>
   </Entries>

--- a/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_00_si_intervention.stringtable
+++ b/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_00_si_intervention.stringtable
@@ -53,14 +53,14 @@ Die Anwesenheit des Gottes schwindet. </DefaultText>
     </Entry>
     <Entry>
       <ID>11</ID>
-      <DefaultText>Lange, muskulöse Ranken steigen aus den Nebel-verhangenen Ruinen empor, geißeln an Eothas' Adra-Torso und schlingen sich um seine Gliedmaßen. Die Tentakel, jede mit tausend Augen bestückt, winden sich um ihre Beute. 
+      <DefaultText>Lange, muskulöse Ranken steigen aus den nebelverhangenen Ruinen empor, geißeln Eothas' Adra-Torso und schlingen sich um seine Gliedmaßen. Die Tentakel, jede mit tausend Augen bestückt, winden sich um ihre Beute. 
 
 Donnerndes Krachen hallt durch die Luft und Licht strömt aus den Rissen und breitet sich über der Statue von Maros Nua aus.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>12</ID>
-      <DefaultText>Eothas greift nach den fleischigen Gliedmaßen, zerdrückt eine in jeder Hand, aber Waels unzählige Arme lassen sich davon nicht abschrecken. Während sie sich zusammenziehen saugt der lebende Titan riesige Mengen an Seele aus Eothas und den Maschinen von Ukaizo.</DefaultText>
+      <DefaultText>Eothas greift nach den fleischigen Gliedmaßen, zerdrückt eine in jeder Hand, aber Waels unzählige Arme lassen sich davon nicht abschrecken. Während sie sich zusammenziehen, saugt der lebende Titan riesige Mengen an Seelen aus Eothas und den Maschinen von Ukaizo.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -72,7 +72,7 @@ Donnerndes Krachen hallt durch die Luft und Licht strömt aus den Rissen und bre
       <ID>15</ID>
       <DefaultText>Eothas fällt auf die alte engwithanische Maschine und greift nach ihr in einem letzten verzweifelten Versuch, den Apparat zu zerreißen. Bänder mit leuchtender Energie strömen aus den zerfallenden Strukturen.
 
-Die Ruinen-Stadt bebt, als Wael Eothas zu Boden zerrt. </DefaultText>
+Die Ruinenstadt bebt, als Wael Eothas zu Boden zerrt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_00_si_opening.stringtable
+++ b/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_00_si_opening.stringtable
@@ -86,7 +86,7 @@
     </Entry>
     <Entry>
       <ID>19</ID>
-      <DefaultText>Der Drache stoppt überhalb der [Player Ship], der Wind von seinen Flügeln bläst dich fast um, als sein Reiter fordernd hinabblickt.</DefaultText>
+      <DefaultText>Der Drache stoppt über der [Player Ship], der Wind von seinen Flügeln bläst dich fast um, als sein Reiter fordernd hinabblickt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -148,7 +148,7 @@ Die Richtung der Wellen legt nah, dass es aus den südlichen Reichweiten des Tod
     </Entry>
     <Entry>
       <ID>34</ID>
-      <DefaultText>Der Drache stoppt überhalb der [Player Ship], der Wind von seinen Flügeln bläst dich fast um, als sein Reiter fordernd hinabblickt.</DefaultText>
+      <DefaultText>Der Drache stoppt über der [Player Ship], der Wind von seinen Flügeln bläst dich fast um, als sein Reiter fordernd hinabblickt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_01_cv_egg_hatching.stringtable
+++ b/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_01_cv_egg_hatching.stringtable
@@ -11,7 +11,7 @@
     </Entry>
     <Entry>
       <ID>2</ID>
-      <DefaultText>Oh, ihr Götter. Es ist das Ei."</DefaultText>
+      <DefaultText>„Oh, ihr Götter. Es ist das Ei.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -82,8 +82,8 @@ Der Körper erschlafft.</DefaultText>
     </Entry>
     <Entry>
       <ID>16</ID>
-      <DefaultText>Was? Hat es dich schief angesehen oder was, Wächter?</DefaultText>
-      <FemaleText>Was? Hat es dich schief angesehen oder was, Wächterin?</FemaleText>
+      <DefaultText>„Was? Hat es dich schief angesehen oder was, Wächter?“</DefaultText>
+      <FemaleText>„Was? Hat es dich schief angesehen oder was, Wächterin?“</FemaleText>
     </Entry>
     <Entry>
       <ID>17</ID>

--- a/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_01_cv_librarian_head.stringtable
+++ b/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_01_cv_librarian_head.stringtable
@@ -6,16 +6,16 @@
   <Entries>
     <Entry>
       <ID>1</ID>
-      <DefaultText>"Sei gegrüßt, Besucher. Dies ist das Skriptorium."
+      <DefaultText>„Sei gegrüßt, Besucher. Dies ist das Skriptorium.“
 
-Eine Frau, ihr Oberkörper ist nur noch Haut und Knochen, neigt sich mit dem Kopf zu dir. Ihre eckige Kieferpartie und die spitzen Ohren lassen vermuten, dass sie eine Elfin ist.</DefaultText>
-      <FemaleText>"Sei gegrüßt, Besucherin. Dies ist das Skriptorium."
+Eine Frau, ihr Oberkörper ist nur noch Haut und Knochen, neigt sich mit dem Kopf zu dir. Ihre eckige Kieferpartie und die spitzen Ohren lassen vermuten, dass sie eine Elfe ist.</DefaultText>
+      <FemaleText>„Sei gegrüßt, Besucherin. Dies ist das Skriptorium.“
 
-Eine Frau, ihr Oberkörper ist nur noch Haut und Knochen, neigt sich mit dem Kopf zu dir. Ihre eckige Kieferpartie und die spitzen Ohren lassen vermuten, dass sie eine Elfin ist.</FemaleText>
+Eine Frau, ihr Oberkörper ist nur noch Haut und Knochen, neigt sich mit dem Kopf zu dir. Ihre eckige Kieferpartie und die spitzen Ohren lassen vermuten, dass sie eine Elfe ist.</FemaleText>
     </Entry>
     <Entry>
       <ID>2</ID>
-      <DefaultText>"Sei gegrüßt, Besucher. "Willkommen zurück im Skriptorium."</DefaultText>
+      <DefaultText>„Sei gegrüßt, Besucher. Willkommen zurück im Skriptorium.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -121,7 +121,7 @@ Sie zeigt auf ein seltsames Gerät im Süden.</DefaultText>
     </Entry>
     <Entry>
       <ID>22</ID>
-      <DefaultText>"Dachtest du, der Spruch ist lustig als du das erste Mal gingst und sagtest es daher wieder, Käpt'n?"
+      <DefaultText>„Dachtest du, der Spruch ist lustig, als du das erste Mal gingst, und sagtest es daher wieder, Käpt'n?“
 
 Serafen schüttelt den Kopf.</DefaultText>
       <FemaleText />
@@ -168,9 +168,9 @@ Serafen schüttelt den Kopf.</DefaultText>
     </Entry>
     <Entry>
       <ID>32</ID>
-      <DefaultText>"Vielleicht. Wenn der Zauberer für sich selbst eine Maske beschafft hat. Bist du ihm begegnet?"
+      <DefaultText>„Vielleicht. Wenn der Zauberer für sich selbst eine Maske beschafft hat. Bist du ihm begegnet?“
 
-Sie hält inne, die Schreibfeder sitz über ihren Seiten.</DefaultText>
+Sie hält inne, die Schreibfeder sitzt über ihren Seiten.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -383,7 +383,7 @@ Sie deutet auf die Schreibgelehrten.</DefaultText>
     </Entry>
     <Entry>
       <ID>78</ID>
-      <DefaultText>"So viel ist hier unten geschehen, das besser vergessen werden sollte. So viel ist da oben geschehen, dass es wert ist, daran erinnert zu werden." Seufzend beugt sich Maia, um auf Ishizas Wappen zu schlagen. </DefaultText>
+      <DefaultText>„So viel ist hier unten geschehen, das besser vergessen werden sollte. So viel ist da oben geschehen, das es wert ist, daran erinnert zu werden.“ Seufzend beugt sich Maia, um Ishizas Federkamm zu streicheln. </DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_01_cv_tayn.stringtable
+++ b/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_01_cv_tayn.stringtable
@@ -1828,7 +1828,7 @@
     </Entry>
     <Entry>
       <ID>544</ID>
-      <DefaultText>"Ich würde ja gerne mit dir in diesen feuchten, fleischigen Alptraum hinabsteigen, aber ich habe noch Erzmagier-Sachen zu erledigen." Tayn nimmt ein Buch, leckt zitternd seinen Daumen ab und blättert mehrere Seiten durch, ohne ein Wort zu lesen. </DefaultText>
+      <DefaultText>„Ich würde ja gerne mit dir in diesen feuchten, fleischigen Albtraum hinabsteigen, aber ich habe noch Erzmagier-Sachen zu erledigen.“ Tayn nimmt ein Buch, leckt zitternd seinen Daumen ab und blättert mehrere Seiten durch, ohne ein Wort zu lesen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>


### PR DESCRIPTION
Schon mal ein Schwung an Änderungen. Mal gucken, ob ich heute Abend noch Lust auf mehr habe. ;-)

In den IDs, wo ich Änderungen gemacht habe, habe ich auch komplett typographische Anführungszeichen gesetzt (und hoffentl. auch an Gedankenstriche und Auslassungspunkte gedacht sowie ggf. Leerzeichen am Satzende entfernt) - die anderen IDs habe ich nicht geändert.

Bei den fehlenden Anführungszeichen (also wörtlicher Rede) habe ich mich i.d.R. an der engl. Version orientiert (außer wenn auch dort eine ungerade Anzahl an " vorlag).