### PR TITLE
diverse Änderungen

### DIFF
--- a/exported/localized/de_patch/text/conversations/companions/companion_maia_main.stringtable
+++ b/exported/localized/de_patch/text/conversations/companions/companion_maia_main.stringtable
@@ -213,7 +213,7 @@ Ishiza kräht voller Erwartung.</DefaultText>
     </Entry>
     <Entry>
       <ID>86</ID>
-      <DefaultText>Unter heftigem Atem beißt Maia auf ihre Backe. Sie hält die Waffe ruhig und präzise, aber der Rest ihres Körpers zittert vor Unentschlossenheit.</DefaultText>
+      <DefaultText>Unter heftigem Atmen beißt Maia auf ihre Backe. Sie hält die Waffe ruhig und präzise, aber der Rest ihres Körpers zittert vor Unentschlossenheit.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -426,7 +426,7 @@ Maia grinst und stemmt die Hände stolz gegen die Hüften.</DefaultText>
     </Entry>
     <Entry>
       <ID>130</ID>
-      <DefaultText>Sie starrt ununterbrochen zurück, und scheint nur dann zu blinzeln, wenn sie gerade daran denkt.</DefaultText>
+      <DefaultText>Sie starrt ununterbrochen zurück und scheint nur dann zu blinzeln, wenn sie gerade daran denkt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -725,7 +725,7 @@ Maia verschränkt die Arme und wartet. Ishiza nimmt die Untersuchung des Fußbod
     </Entry>
     <Entry>
       <ID>196</ID>
-      <DefaultText>„Wenn … wenn es dir so lieber ist.“ Maia öffnet ihren Mund, um noch etwas zu sagen, aber überdenkt das Ganze und schließt und dann wieder.</DefaultText>
+      <DefaultText>„Wenn … wenn es dir so lieber ist.“ Maia öffnet ihren Mund, um noch etwas zu sagen, aber überdenkt das Ganze und schließt ihn dann wieder.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax1_exported/localized/de_patch/text/conversations/lax/lax_cv_craftsperson.stringtable
+++ b/lax1_exported/localized/de_patch/text/conversations/lax/lax_cv_craftsperson.stringtable
@@ -50,7 +50,7 @@ Die Zwergin nähert sich dir. Die Luft um sie herum riecht scharf nach Öl und M
     </Entry>
     <Entry>
       <ID>10</ID>
-      <DefaultText>„Was für ein merkwürdiges Metall! Was hast du denn sonst noch so für mich?“ Sie gibt dir Neriscyrlas' Hoffnung zurück und wühlt weiter in deinen Besitztümern.</DefaultText>
+      <DefaultText>„Was für ein merkwürdiges Metall! Was hast du denn sonst noch so für mich?“ Sie gibt dir Neriscyrlas’ Hoffnung zurück und wühlt weiter in deinen Besitztümern.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -147,7 +147,7 @@ Sie greift sich ein Tuch, mit dem sie dir vorsichtig die Stücke leuchtendes Met
     </Entry>
     <Entry>
       <ID>32</ID>
-      <DefaultText>[Ihr Neriscyrlas Hoffnung, Zahn des Toamowhai und das Gewicht der Offenbarung geben.] „Kannst du diese drei Einzelteile zu einem Ganzen schmieden?“</DefaultText>
+      <DefaultText>[Ihr Neriscyrlas’ Hoffnung, Zahn des Toamowhai und das Gewicht der Offenbarung geben.] „Kannst du diese drei Einzelteile zu einem Ganzen schmieden?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -159,7 +159,7 @@ Sobald sie sich an die Arbeit gemacht hat, überkommt dich etwas. Deine Haut fü
     </Entry>
     <Entry>
       <ID>34</ID>
-      <DefaultText>[Ihr Neriscyrlas' Hoffnung geben.] „Kannst du das mit der Kette der rechtmäßigen Autorität verschmelzen?“</DefaultText>
+      <DefaultText>[Ihr Neriscyrlas’ Hoffnung geben.] „Kannst du das mit der Kette der rechtmäßigen Autorität verschmelzen?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -176,7 +176,7 @@ Lächelnd präsentiert dir Izzia die Früchte ihrer Arbeit.</DefaultText>
     </Entry>
     <Entry>
       <ID>39</ID>
-      <DefaultText>[Ihr Neriscyrlas' Hoffnung und den Zahn des Toamowhai geben.] „Was kannst du mir aus diesen beiden Artefakten schmieden?“</DefaultText>
+      <DefaultText>[Ihr Neriscyrlas’ Hoffnung und den Zahn des Toamowhai geben.] „Was kannst du mir aus diesen beiden Artefakten schmieden?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -186,7 +186,7 @@ Lächelnd präsentiert dir Izzia die Früchte ihrer Arbeit.</DefaultText>
     </Entry>
     <Entry>
       <ID>41</ID>
-      <DefaultText>[Ihr Neriscyrlas' Hoffnung und das Gewicht der Offenbarung geben.] „Was kannst du mir aus diesen beiden Artefakten schmieden?“</DefaultText>
+      <DefaultText>[Ihr Neriscyrlas’ Hoffnung und das Gewicht der Offenbarung geben.] „Was kannst du mir aus diesen beiden Artefakten schmieden?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -374,7 +374,7 @@ Sie lächelt gutgelaunt und zuckt mit den Schultern.</DefaultText>
     </Entry>
     <Entry>
       <ID>92</ID>
-      <DefaultText>[Ihr Neriscyrlas' Hoffnung und den Zahn des Toamowhai geben.] „Verschmelze diese beiden miteinander.“</DefaultText>
+      <DefaultText>[Ihr Neriscyrlas’ Hoffnung und den Zahn des Toamowhai geben.] „Verschmelze diese beiden miteinander.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -384,7 +384,7 @@ Sie lächelt gutgelaunt und zuckt mit den Schultern.</DefaultText>
     </Entry>
     <Entry>
       <ID>94</ID>
-      <DefaultText>[Ihr Neriscyrlas Hoffnung und das Gewicht der Offenbarung geben.] „Schmiede diese beiden Einzelteile zu einem Stück.“</DefaultText>
+      <DefaultText>[Ihr Neriscyrlas’ Hoffnung und das Gewicht der Offenbarung geben.] „Schmiede diese beiden Einzelteile zu einem Stück.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax1_exported/localized/de_patch/text/conversations/lax/lax_cv_shards.stringtable
+++ b/lax1_exported/localized/de_patch/text/conversations/lax/lax_cv_shards.stringtable
@@ -13,27 +13,27 @@ Ein Puls, der nicht der deine ist, pocht in deinen Ohren.</DefaultText>
     </Entry>
     <Entry>
       <ID>2</ID>
-      <DefaultText>Der Puls stammt aus Neriscyrlas Hoffnung, dem Zahn des Toamowhai und dem Gewicht der Offenbarung.</DefaultText>
+      <DefaultText>Der Puls stammt aus Neriscyrlas’ Hoffnung, dem Zahn des Toamowhai und dem Gewicht der Offenbarung.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>3</ID>
-      <DefaultText>Der Puls stammt aus der Kette der rechtmäßigen Autorität und Neriscyrlas Hoffnung.</DefaultText>
+      <DefaultText>Der Puls stammt aus der Kette der rechtmäßigen Autorität und Neriscyrlas’ Hoffnung.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>4</ID>
-      <DefaultText>Der Puls stammt aus Neriscyrlas Hoffnung und dem Zahn des Toamowhai.</DefaultText>
+      <DefaultText>Der Puls stammt aus Neriscyrlas’ Hoffnung und dem Zahn des Toamowhai.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>5</ID>
-      <DefaultText>Der Puls stammt aus Neriscyrlas Hoffnung und dem Gewicht der Offenbarung.</DefaultText>
+      <DefaultText>Der Puls stammt aus Neriscyrlas’ Hoffnung und dem Gewicht der Offenbarung.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>6</ID>
-      <DefaultText>Der Puls stammt aus Neriscyrlas Hoffnung, dem Zahn des Toamowhai und dem Gewicht der Offenbarung.</DefaultText>
+      <DefaultText>Der Puls stammt aus Neriscyrlas’ Hoffnung, dem Zahn des Toamowhai und dem Gewicht der Offenbarung.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax1_exported/localized/de_patch/text/conversations/lax01_00_arena_island/lax01_00_cv_aexica.stringtable
+++ b/lax1_exported/localized/de_patch/text/conversations/lax01_00_arena_island/lax01_00_cv_aexica.stringtable
@@ -1232,7 +1232,7 @@ Sie runzelt die Stirn.</DefaultText>
     </Entry>
     <Entry>
       <ID>353</ID>
-      <DefaultText>„Hole den Zahn von Toamowhai von Whehami zurück.“</DefaultText>
+      <DefaultText>„Hole den Zahn des Toamowhai von Whehami zurück.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax1_exported/localized/de_patch/text/game/items.stringtable
+++ b/lax1_exported/localized/de_patch/text/game/items.stringtable
@@ -22,7 +22,7 @@ Er machte daraus einen Helm, den er bis zu seinem Lebensende trug. Er vermachte 
     </Entry>
     <Entry>
       <ID>4351</ID>
-      <DefaultText>Umhänge wie dieser waren einst bei den erfahrensten Fischern und Haijägern der Huana-Stämme geläufig. Sie wurden aus Schichten dicker Robbenhäute genäht und zum Schutz vor den Elementen eingeölt. Sie dienten nicht nur dem praktischen Zweck, den Träger relativ warm und trocken zu halten und ihn von zuschnappenden Zähnen und peitschenden Tentakeln zu schützen, sondern waren auch ein Statussymbol: Wer in diese Häute gekleidet war, hatte sich in Ngatis unbarmherziges Reich vorgewagt, um den Stamm zu versorgen. Dieser spezifischer Umhang trägt die Spuren jahrelangen schweren Gebrauchs. Seine Nähte sind ausgefranst und seine Ränder zerfetzt. Trotz der deutlichen Abnutzung schützt der zähe Aufbau dieses Mantels immer noch vor Wasser und Kälte.</DefaultText>
+      <DefaultText>Umhänge wie dieser waren einst bei den erfahrensten Fischern und Haijägern der Huana-Stämme geläufig. Sie wurden aus Schichten dicker Robbenhäute genäht und zum Schutz vor den Elementen eingeölt. Sie dienten nicht nur dem praktischen Zweck, den Träger relativ warm und trocken zu halten und ihn von zuschnappenden Zähnen und peitschenden Tentakeln zu schützen, sondern waren auch ein Statussymbol: Wer in diese Häute gekleidet war, hatte sich in Ngatis unbarmherziges Reich vorgewagt, um den Stamm zu versorgen. Dieser spezifische Umhang trägt die Spuren jahrelangen schweren Gebrauchs. Seine Nähte sind ausgefranst und seine Ränder zerfetzt. Trotz der deutlichen Abnutzung schützt der zähe Aufbau dieses Mantels immer noch vor Wasser und Kälte.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -61,7 +61,7 @@ Osara Haru, eine wohlhabende Anteilseignerin der Königlichen Todesfeuer-Gesell
       <ID>4382</ID>
       <DefaultText>Die blutrünstigen Wettkämpfer des Schmelztiegels waren für den Entwurf dieses brutalen Faustschilds verantwortlich. Ein mit Widerhaken versehener Stahldorn ragt aus der Mitte hervor und soll Platten, Ketten und Haut durchdringen. Die Blutflecken auf dem Schild lassen sich nicht entfernen, ganz egal wie oft man diesen schrubbt. Beim Anblick des Faustschilds zucken Kämpfer angsterfüllt zusammen und sanftmütigere Zuschauer verziehen das Gesicht, denn der Schild ruft ungewollte Erinnerungen an Erzählungen über scheinbar verlorene Kämpfe hervor, deren Ausgang durch einen rechtzeitig ausgeführten Schildschlag in Bauch, Leiste oder Auge gewendet wurde.
 
-Obwohl niemand zu wissen scheint, wer diesen Faustschild ursprünglich hergestellt hat, bezeugen die Bewohner von Kazuwari, dass er in im Lauf der Jahre von dutzenden Kämpfern in der Arena geführt wurde. Dass du den Schild geerbt hast, lässt vermuten, dass seine vorherigen Besitzer die grausame letzte Lektion des Schmelztiegels gelernt haben: Selbst die Kämpfer mit den besten Waffen zollen irgendwann der Grube Tribut.</DefaultText>
+Obwohl niemand zu wissen scheint, wer diesen Faustschild ursprünglich hergestellt hat, bezeugen die Bewohner von Kazuwari, dass er im Lauf der Jahre von dutzenden Kämpfern in der Arena geführt wurde. Dass du den Schild geerbt hast, lässt vermuten, dass seine vorherigen Besitzer die grausame letzte Lektion des Schmelztiegels gelernt haben: Selbst die Kämpfer mit den besten Waffen zollen irgendwann der Grube Tribut.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -188,7 +188,7 @@ Die Flüssigkeit schmeckt leicht säuerlich.</DefaultText>
     </Entry>
     <Entry>
       <ID>4574</ID>
-      <DefaultText>Dieses solide Stück polierten Wacholderholzes scheint unglaublich schlank zu sein, seine aufwendig gewundenen Wurfarme vermitteln das Bild von gefiederten Flügeln im Flug, wodurch eine Fraktur nahezu heraufbeschwört wird. Und dennoch gibt der Bogen bereitwillig und ohne Anzeichen von Sprödigkeit nach, wenn der Bogenschütze den festen Seidensehne spannt.
+      <DefaultText>Dieses solide Stück polierten Wacholderholzes scheint unglaublich schlank zu sein, seine aufwendig gewundenen Wurfarme vermitteln das Bild von gefiederten Flügeln im Flug, wodurch eine Fraktur nahezu heraufbeschworen wird. Und dennoch gibt der Bogen bereitwillig und ohne Anzeichen von Sprödigkeit nach, wenn der Bogenschütze die feste Seidensehne spannt.
 
 Wenn er gespannt wird, scheinen die gefiederten Wurfarme des Bogens sich zu sträuben, während der Griff so fest klammert wie der Bogenschütze den Bogen. Der Blick entlang eines eingelegten Pfeils verschärft das Ziel und verbessert die Sicht des Schützen wie die eines Fischadlers.
 
@@ -352,7 +352,7 @@ So singen es die Huana. So heulen es die Gesichter der Jagd.</DefaultText>
     </Entry>
     <Entry>
       <ID>4735</ID>
-      <DefaultText>Dieser einfache Helm gehört zur Ausrüstung der Wärter der Schmelztiegel-Arena. Die Aufnahme in ihre ehrenhaften Ränge umfasst das Aufspüren eines seltenen Vogels in den Tiefen der Kazuwari-Wildnis und den Raub von ausreichend Federn für die dekorative Befiederung ihres Helms. Einige Anwärter versuchen törichterweise, diesen Ritus zu überspringen, indem sie ihre eigenen Feder einfärben oder kaufen. Die Ältesten erkennen den Unterschied jedoch immer. Der Trick besteht darin, den Wärter zu studieren. Einer, der mit Stolz zurückkehrt, wird als Betrüger abgelehnt. Einer, der mit Bescheidenheit zurückkehrt, ist wahrheitsgetreu.</DefaultText>
+      <DefaultText>Dieser einfache Helm gehört zur Ausrüstung der Wärter der Schmelztiegel-Arena. Die Aufnahme in ihre ehrenhaften Ränge umfasst das Aufspüren eines seltenen Vogels in den Tiefen der Kazuwari-Wildnis und den Raub von ausreichend Federn für die dekorative Befiederung ihres Helms. Einige Anwärter versuchen törichterweise, diesen Ritus zu überspringen, indem sie ihre eigenen Federn einfärben oder kaufen. Die Ältesten erkennen den Unterschied jedoch immer. Der Trick besteht darin, den Wärter zu studieren. Einer, der mit Stolz zurückkehrt, wird als Betrüger abgelehnt. Einer, der mit Bescheidenheit zurückkehrt, ist wahrheitsgetreu.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -526,7 +526,7 @@ Als die Rauataianer in das Todesfeuer strömten, setzte Metani Ngatis Stoßzahn 
     </Entry>
     <Entry>
       <ID>4874</ID>
-      <DefaultText>Dieser gekrönte Helm schützt nicht nur den Kopf, das Gesicht und den Hals seines Trägers sondern kennzeichnet auch jene, die in Rang und Ansehen im Schmelztiegel aufgestiegen sind. Dekorative Gravierungen verleihen dem Träger ein stoisches Aussehen, und die offenen Gucklöcher unterstreichen die Notwendigkeit, die Augen aus der Hitze des Gefechts zu halten.</DefaultText>
+      <DefaultText>Dieser gekrönte Helm schützt nicht nur den Kopf, das Gesicht und den Hals seines Trägers, sondern kennzeichnet auch jene, die in Rang und Ansehen im Schmelztiegel aufgestiegen sind. Dekorative Gravierungen verleihen dem Träger ein stoisches Aussehen, und die offenen Gucklöcher unterstreichen die Notwendigkeit, die Augen aus der Hitze des Gefechts zu halten.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -594,7 +594,7 @@ Die undeutlichen &lt;xg&gt;Figuren&lt;/xg&gt;, die auf diesem Wandteppich darges
     </Entry>
     <Entry>
       <ID>4999</ID>
-      <DefaultText>Das hölzerne Ohr von Ifren, des Wahrsagers im Dunklen Schrank von zweifelhaftem Talent, ist rau und splittert durch die Abtrennung.</DefaultText>
+      <DefaultText>Das hölzerne Ohr von Ifren, dem Wahrsager von zweifelhaftem Talent im Dunklen Schrank, ist rau und splittert durch die Abtrennung.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -624,7 +624,7 @@ Die undeutlichen &lt;xg&gt;Figuren&lt;/xg&gt;, die auf diesem Wandteppich darges
     </Entry>
     <Entry>
       <ID>5007</ID>
-      <DefaultText>Dieser tränenförmige Klumpen Adra ruht in den korrodierten Überresten eines Kupferrahmens. Ein haarfeiner Riss verläuft durch den Stein entzwei, ansonsten ist der Adra in hervorragendem Zustand.
+      <DefaultText>Dieser tränenförmige Klumpen Adra ruht in den korrodierten Überresten eines Kupferrahmens. Ein haarfeiner Riss verläuft durch den Stein, ansonsten ist der Adra in hervorragendem Zustand.
 
 Obwohl er bereits vor Jahrhunderten oder noch länger aus dem Boden gewonnen wurde, bewahrt der Adra einen schwachen, leuchtenden Schimmer.</DefaultText>
       <FemaleText />
@@ -658,7 +658,7 @@ Obwohl er bereits vor Jahrhunderten oder noch länger aus dem Boden gewonnen wur
       <ID>5440</ID>
       <DefaultText>Dieser angespitzte Metallsplitter klimpert vor unverbrauchter Energie. Goldbänder flimmern und erlöschen regelmäßig wie lebendige Asche, die unter seiner Onyx-Oberfläche gefangen ist. Ein zerbrochener Rand deutet darauf hin, dass er entweder abgeschlagen wurde oder durch irgendein größeres Objekt geschmolzen ist. Was es war, und wie es so wurde, ist ein Geheimnis.
 
-In jüngerer Vergangenheit wurde er als Zahn von Toamowhai bezeichnet und verwendet, um eine Adrasäule zu zerschlagen. Das Ausmaß seiner Macht kann nur vermutet werden.</DefaultText>
+In jüngerer Vergangenheit wurde er als Zahn des Toamowhai bezeichnet und verwendet, um eine Adrasäule zu zerschlagen. Das Ausmaß seiner Macht kann nur vermutet werden.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax2_exported/localized/de_patch/text/conversations/lax/lax_cv_craftsperson.stringtable
+++ b/lax2_exported/localized/de_patch/text/conversations/lax/lax_cv_craftsperson.stringtable
@@ -50,7 +50,7 @@ Die Zwergin nähert sich dir. Die Luft um sie herum riecht scharf nach Öl und M
     </Entry>
     <Entry>
       <ID>10</ID>
-      <DefaultText>„Was für ein merkwürdiges Metall! Was hast du denn sonst noch so für mich?“ Sie gibt dir Neriscyrlas' Hoffnung zurück und wühlt weiter in deinen Besitztümern.</DefaultText>
+      <DefaultText>„Was für ein merkwürdiges Metall! Was hast du denn sonst noch so für mich?“ Sie gibt dir Neriscyrlas’ Hoffnung zurück und wühlt weiter in deinen Besitztümern.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -147,7 +147,7 @@ Sie greift sich ein Tuch, mit dem sie dir vorsichtig die Stücke leuchtendes Met
     </Entry>
     <Entry>
       <ID>32</ID>
-      <DefaultText>[Ihr Neriscyrlas Hoffnung, Zahn des Toamowhai und das Gewicht der Offenbarung geben.] „Kannst du diese drei Einzelteile zu einem Ganzen schmieden?“</DefaultText>
+      <DefaultText>[Ihr Neriscyrlas’ Hoffnung, Zahn des Toamowhai und das Gewicht der Offenbarung geben.] „Kannst du diese drei Einzelteile zu einem Ganzen schmieden?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -159,7 +159,7 @@ Sobald sie sich an die Arbeit gemacht hat, überkommt dich etwas. Deine Haut fü
     </Entry>
     <Entry>
       <ID>34</ID>
-      <DefaultText>[Ihr Neriscyrlas' Hoffnung geben.] „Kannst du das mit der Kette der rechtmäßigen Autorität verschmelzen?“</DefaultText>
+      <DefaultText>[Ihr Neriscyrlas’ Hoffnung geben.] „Kannst du das mit der Kette der rechtmäßigen Autorität verschmelzen?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -176,7 +176,7 @@ Lächelnd präsentiert dir Izzia die Früchte ihrer Arbeit.</DefaultText>
     </Entry>
     <Entry>
       <ID>39</ID>
-      <DefaultText>[Ihr Neriscyrlas' Hoffnung und den Zahn des Toamowhai geben.] „Was kannst du mir aus diesen beiden Artefakten schmieden?“</DefaultText>
+      <DefaultText>[Ihr Neriscyrlas’ Hoffnung und den Zahn des Toamowhai geben.] „Was kannst du mir aus diesen beiden Artefakten schmieden?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -186,7 +186,7 @@ Lächelnd präsentiert dir Izzia die Früchte ihrer Arbeit.</DefaultText>
     </Entry>
     <Entry>
       <ID>41</ID>
-      <DefaultText>[Ihr Neriscyrlas' Hoffnung und das Gewicht der Offenbarung geben.] „Was kannst du mir aus diesen beiden Artefakten schmieden?“</DefaultText>
+      <DefaultText>[Ihr Neriscyrlas’ Hoffnung und das Gewicht der Offenbarung geben.] „Was kannst du mir aus diesen beiden Artefakten schmieden?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -374,7 +374,7 @@ Sie lächelt gutgelaunt und zuckt mit den Schultern.</DefaultText>
     </Entry>
     <Entry>
       <ID>92</ID>
-      <DefaultText>[Ihr Neriscyrlas' Hoffnung und den Zahn des Toamowhai geben.] „Verschmelze diese beiden miteinander.“</DefaultText>
+      <DefaultText>[Ihr Neriscyrlas’ Hoffnung und den Zahn des Toamowhai geben.] „Verschmelze diese beiden miteinander.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -384,7 +384,7 @@ Sie lächelt gutgelaunt und zuckt mit den Schultern.</DefaultText>
     </Entry>
     <Entry>
       <ID>94</ID>
-      <DefaultText>[Ihr Neriscyrlas Hoffnung und das Gewicht der Offenbarung geben.] „Schmiede diese beiden Einzelteile zu einem Stück.“</DefaultText>
+      <DefaultText>[Ihr Neriscyrlas’ Hoffnung und das Gewicht der Offenbarung geben.] „Schmiede diese beiden Einzelteile zu einem Stück.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax2_exported/localized/de_patch/text/conversations/lax/lax_cv_shards.stringtable
+++ b/lax2_exported/localized/de_patch/text/conversations/lax/lax_cv_shards.stringtable
@@ -13,27 +13,27 @@ Ein Puls, der nicht der deine ist, pocht in deinen Ohren.</DefaultText>
     </Entry>
     <Entry>
       <ID>2</ID>
-      <DefaultText>Der Puls stammt aus Neriscyrlas Hoffnung, dem Zahn des Toamowhai und dem Gewicht der Offenbarung.</DefaultText>
+      <DefaultText>Der Puls stammt aus Neriscyrlas’ Hoffnung, dem Zahn des Toamowhai und dem Gewicht der Offenbarung.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>3</ID>
-      <DefaultText>Der Puls stammt aus der Kette der rechtmäßigen Autorität und Neriscyrlas Hoffnung.</DefaultText>
+      <DefaultText>Der Puls stammt aus der Kette der rechtmäßigen Autorität und Neriscyrlas’ Hoffnung.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>4</ID>
-      <DefaultText>Der Puls stammt aus Neriscyrlas Hoffnung und dem Zahn des Toamowhai.</DefaultText>
+      <DefaultText>Der Puls stammt aus Neriscyrlas’ Hoffnung und dem Zahn des Toamowhai.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>5</ID>
-      <DefaultText>Der Puls stammt aus Neriscyrlas Hoffnung und dem Gewicht der Offenbarung.</DefaultText>
+      <DefaultText>Der Puls stammt aus Neriscyrlas’ Hoffnung und dem Gewicht der Offenbarung.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>6</ID>
-      <DefaultText>Der Puls stammt aus Neriscyrlas Hoffnung, Toamowhais Zahn und dem Gewicht der Offenbarung.</DefaultText>
+      <DefaultText>Der Puls stammt aus Neriscyrlas’ Hoffnung, Toamowhais Zahn und dem Gewicht der Offenbarung.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax2_exported/localized/de_patch/text/quests/lax02_01_iceberg_dungeon/lax02_qst_critical_path_quest_03.stringtable
+++ b/lax2_exported/localized/de_patch/text/quests/lax02_01_iceberg_dungeon/lax02_qst_critical_path_quest_03.stringtable
@@ -67,7 +67,7 @@ Wenn ich sie verfolgen will, muss ich in die Grube hinabsteigen, die sie in der 
     </Entry>
     <Entry>
       <ID>10004</ID>
-      <DefaultText>Nachdem ich sie gestellt hatte, zerfiel Neriscyrlas Hort und spuckte mich in die Tundra des Weißen Nichts aus.
+      <DefaultText>Nachdem ich sie gestellt hatte, zerfiel Neriscyrlas’ Hort und spuckte mich in die Tundra des Weißen Nichts aus.
 
 Rymrgand und Rynhaedr warnten mich beide, dass es aus diesen Tiefen keine Rückkehr mehr gab. Wenn ich sie widerlegen will und nach Eora zurückkehren will, muss ich das Reich nach einem &lt;b&gt;Ausgang&lt;/b&gt; durchforsten.</DefaultText>
       <FemaleText />

--- a/lax3_exported/localized/de_patch/text/conversations/lax/lax_cv_craftsperson.stringtable
+++ b/lax3_exported/localized/de_patch/text/conversations/lax/lax_cv_craftsperson.stringtable
@@ -48,7 +48,7 @@ Die Zwergin nähert sich dir. Die Luft um sie herum riecht scharf nach Öl und M
     </Entry>
     <Entry>
       <ID>10</ID>
-      <DefaultText>„Was für ein merkwürdiges Metall! Was hast du denn sonst noch so für mich?“ Sie gibt dir Neriscyrlas' Hoffnung zurück und wühlt weiter in deinen Besitztümern.</DefaultText>
+      <DefaultText>„Was für ein merkwürdiges Metall! Was hast du denn sonst noch so für mich?“ Sie gibt dir Neriscyrlas’ Hoffnung zurück und wühlt weiter in deinen Besitztümern.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -145,7 +145,7 @@ Sie greift sich ein Tuch, mit dem sie dir vorsichtig die Stücke leuchtendes Met
     </Entry>
     <Entry>
       <ID>32</ID>
-      <DefaultText>[Ihr Neriscyrlas Hoffnung, den Zahn des Toamowhai und das Gewicht der Offenbarung geben.] „Kannst du diese drei Einzelteile zu einem Ganzen schmieden?“</DefaultText>
+      <DefaultText>[Ihr Neriscyrlas’ Hoffnung, den Zahn des Toamowhai und das Gewicht der Offenbarung geben.] „Kannst du diese drei Einzelteile zu einem Ganzen schmieden?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -157,7 +157,7 @@ Sobald sie sich an die Arbeit gemacht hat, überkommt dich etwas. Deine Haut fü
     </Entry>
     <Entry>
       <ID>34</ID>
-      <DefaultText>[Ihr Neriscyrlas' Hoffnung geben.] „Kannst du das mit der Kette der rechtmäßigen Autorität verschmelzen?“</DefaultText>
+      <DefaultText>[Ihr Neriscyrlas’ Hoffnung geben.] „Kannst du das mit der Kette der rechtmäßigen Autorität verschmelzen?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -174,7 +174,7 @@ Lächelnd präsentiert dir Izzia die Früchte ihrer Arbeit.</DefaultText>
     </Entry>
     <Entry>
       <ID>39</ID>
-      <DefaultText>[Ihr Neriscyrlas' Hoffnung und den Zahn des Toamowhai geben.] „Was kannst du mir aus diesen beiden Artefakten schmieden?“</DefaultText>
+      <DefaultText>[Ihr Neriscyrlas’ Hoffnung und den Zahn des Toamowhai geben.] „Was kannst du mir aus diesen beiden Artefakten schmieden?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -372,7 +372,7 @@ Sie lächelt gutgelaunt und zuckt mit den Schultern.</DefaultText>
     </Entry>
     <Entry>
       <ID>92</ID>
-      <DefaultText>[Ihr Neriscyrlas' Hoffnung und den Zahn des Toamowhai geben.] „Verschmelze diese beiden miteinander.“</DefaultText>
+      <DefaultText>[Ihr Neriscyrlas’ Hoffnung und den Zahn des Toamowhai geben.] „Verschmelze diese beiden miteinander.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -382,7 +382,7 @@ Sie lächelt gutgelaunt und zuckt mit den Schultern.</DefaultText>
     </Entry>
     <Entry>
       <ID>94</ID>
-      <DefaultText>[Ihr Neriscyrlas Hoffnung und das Gewicht der Offenbarung geben.] „Schmiede diese beiden Einzelteile zu einem Stück.“</DefaultText>
+      <DefaultText>[Ihr Neriscyrlas’ Hoffnung und das Gewicht der Offenbarung geben.] „Schmiede diese beiden Einzelteile zu einem Stück.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax3_exported/localized/de_patch/text/conversations/lax/lax_cv_shards.stringtable
+++ b/lax3_exported/localized/de_patch/text/conversations/lax/lax_cv_shards.stringtable
@@ -13,27 +13,27 @@ Ein Puls, der nicht der deine ist, pocht in deinen Ohren.</DefaultText>
     </Entry>
     <Entry>
       <ID>2</ID>
-      <DefaultText>Der Puls stammt aus Neriscyrlas Hoffnung, dem Zahn des Toamowhai und dem Gewicht der Offenbarung.</DefaultText>
+      <DefaultText>Der Puls stammt aus Neriscyrlas’ Hoffnung, dem Zahn des Toamowhai und dem Gewicht der Offenbarung.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>3</ID>
-      <DefaultText>Der Puls stammt aus der Kette der rechtmäßigen Autorität und Neriscyrlas Hoffnung.</DefaultText>
+      <DefaultText>Der Puls stammt aus der Kette der rechtmäßigen Autorität und Neriscyrlas’ Hoffnung.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>4</ID>
-      <DefaultText>Der Puls stammt aus Neriscyrlas Hoffnung und dem Zahn des Toamowhai.</DefaultText>
+      <DefaultText>Der Puls stammt aus Neriscyrlas’ Hoffnung und dem Zahn des Toamowhai.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>5</ID>
-      <DefaultText>Der Puls stammt aus Neriscyrlas Hoffnung und dem Gewicht der Offenbarung.</DefaultText>
+      <DefaultText>Der Puls stammt aus Neriscyrlas’ Hoffnung und dem Gewicht der Offenbarung.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>6</ID>
-      <DefaultText>Der Puls stammt aus Neriscyrlas Hoffnung, dem Zahn des Toamowhai und dem Gewicht der Offenbarung.</DefaultText>
+      <DefaultText>Der Puls stammt aus Neriscyrlas’ Hoffnung, dem Zahn des Toamowhai und dem Gewicht der Offenbarung.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>


### PR DESCRIPTION
- ich habe druchgängig einen typographischen Apostroph in "Neriscyrlas' Hoffnung" gesetzt, wo noch keriner war - tlw. gab es gar keinen, tlw. das Standardzeichen
- außerdem die letzten beiden Stellen geändert, an denen es noch "Zahn von Toamowhai" hieß (von -> des)
- diverses