### PR TITLE
Drachin und Heroldine

### DIFF
--- a/exported/localized/de_patch/text/chatter/07_neketaka_temple_district/ch_07_guards.stringtable
+++ b/exported/localized/de_patch/text/chatter/07_neketaka_temple_district/ch_07_guards.stringtable
@@ -57,7 +57,7 @@
     <Entry>
       <ID>46</ID>
       <DefaultText>„Der Herold von Berath! Bist du hier, um den Priester zu sehen?“</DefaultText>
-      <FemaleText />
+      <FemaleText>„Beraths Herold! Bist du hier, um den Priester zu sehen?“</FemaleText>
     </Entry>
     <Entry>
       <ID>47</ID>

--- a/exported/localized/de_patch/text/chatter/07_neketaka_temple_district/ch_07_townies_general.stringtable
+++ b/exported/localized/de_patch/text/chatter/07_neketaka_temple_district/ch_07_townies_general.stringtable
@@ -122,7 +122,7 @@
     <Entry>
       <ID>46</ID>
       <DefaultText>„Der Herold von Berath! Bist du hier, um den Priester zu sehen?“</DefaultText>
-      <FemaleText />
+      <FemaleText>„Beraths Herold! Bist du hier, um den Priester zu sehen?“</FemaleText>
     </Entry>
     <Entry>
       <ID>47</ID>

--- a/exported/localized/de_patch/text/conversations/03_neketaka_vailian_district/03_cv_director_castol.stringtable
+++ b/exported/localized/de_patch/text/conversations/03_neketaka_vailian_district/03_cv_director_castol.stringtable
@@ -1932,7 +1932,7 @@ Er vergräbt das Gesicht in seinen Händen.</DefaultText>
     <Entry>
       <ID>435</ID>
       <DefaultText>„Ich bin der Herold von Berath. Solche Aufgaben sind meiner nicht würdig.“</DefaultText>
-      <FemaleText />
+      <FemaleText>„Ich bin Beraths Herold. Solche Aufgaben sind meiner nicht würdig.“</FemaleText>
     </Entry>
     <Entry>
       <ID>436</ID>

--- a/exported/localized/de_patch/text/conversations/03_neketaka_vailian_district/03_cv_kaoha.stringtable
+++ b/exported/localized/de_patch/text/conversations/03_neketaka_vailian_district/03_cv_kaoha.stringtable
@@ -228,7 +228,7 @@ Durch den Lärm hörst du die Stimme einer dir bekannten Frau. Sie spricht langs
     <Entry>
       <ID>44</ID>
       <DefaultText>„Ich bin ein Wächter und der Herold von Berath. Das gesamte Todesfeuer ist in Gefahr. Bitte lass mich durch.“</DefaultText>
-      <FemaleText>„Ich bin eine Wächterin und der Herold von Berath. Das gesamte Todesfeuer ist in Gefahr. Bitte lass mich durch.“</FemaleText>
+      <FemaleText>„Ich bin eine Wächterin und Beraths Herold. Das gesamte Todesfeuer ist in Gefahr. Bitte lass mich durch.“</FemaleText>
     </Entry>
     <Entry>
       <ID>45</ID>
@@ -238,7 +238,7 @@ Durch den Lärm hörst du die Stimme einer dir bekannten Frau. Sie spricht langs
     <Entry>
       <ID>46</ID>
       <DefaultText>„Ich bin ein Wächter und der Herold von Berath. Tritt beiseite oder trage die Konsequenzen.“</DefaultText>
-      <FemaleText>„Ich bin eine Wächterin und der Herold von Berath. Tritt beiseite oder trage die Konsequenzen.“</FemaleText>
+      <FemaleText>„Ich bin eine Wächterin und Beraths Herold. Tritt beiseite oder trage die Konsequenzen.“</FemaleText>
     </Entry>
     <Entry>
       <ID>47</ID>

--- a/exported/localized/de_patch/text/conversations/04_neketaka_palace_district/04_cv_queen_onezaka_ii.stringtable
+++ b/exported/localized/de_patch/text/conversations/04_neketaka_palace_district/04_cv_queen_onezaka_ii.stringtable
@@ -1820,7 +1820,7 @@ Sie bricht ab, nickt besorgt.</DefaultText>
     <Entry>
       <ID>596</ID>
       <DefaultText>„Der Herold von Berath ist hier willkommen, würde ich sagen.“ Onekaza neigt den Kopf.</DefaultText>
-      <FemaleText />
+      <FemaleText>„Beraths Herold ist hier willkommen, würde ich sagen.“ Onekaza neigt den Kopf.</FemaleText>
     </Entry>
     <Entry>
       <ID>597</ID>

--- a/exported/localized/de_patch/text/conversations/04_neketaka_palace_district/04_cv_rdc06_prince_aruihi.stringtable
+++ b/exported/localized/de_patch/text/conversations/04_neketaka_palace_district/04_cv_rdc06_prince_aruihi.stringtable
@@ -23,7 +23,9 @@ Aruihi beißt die Zähne zusammen, hebt seinen Hammer hoch und macht sich bereit
       <DefaultText>„Krieger! Für Onekaza und ihre Stadt, zeigt dem Herold von Berath euren Zorn!“
 
 Aruihi stößt einen Kampfschrei aus und hebt seinen Hammer.</DefaultText>
-      <FemaleText />
+      <FemaleText>„Krieger! Für Onekaza und ihre Stadt, zeigt Beraths Herold euren Zorn!“
+
+Aruihi stößt einen Kampfschrei aus und hebt seinen Hammer.</FemaleText>
     </Entry>
     <Entry>
       <ID>5</ID>

--- a/exported/localized/de_patch/text/conversations/04_neketaka_palace_district/04_tree_prince_hub.stringtable
+++ b/exported/localized/de_patch/text/conversations/04_neketaka_palace_district/04_tree_prince_hub.stringtable
@@ -346,7 +346,7 @@ Aruihi nickt Maia zu. Sie runzelt die Stirn und blickt nach hinten.</DefaultText
     <Entry>
       <ID>261</ID>
       <DefaultText>„Der Herold von Berath. Irgendwelche Neuigkeiten aus Tangaloas Schlund?“ Aruihi hebt die Augenbrauen und bedeutet dir, frei zu sprechen.</DefaultText>
-      <FemaleText />
+      <FemaleText>„Beraths Herold. Irgendwelche Neuigkeiten aus Tangaloas Schlund?“ Aruihi hebt die Augenbrauen und bedeutet dir, frei zu sprechen.</FemaleText>
     </Entry>
     <Entry>
       <ID>262</ID>

--- a/exported/localized/de_patch/text/conversations/09_port_maje/09_cv_beach_landing.stringtable
+++ b/exported/localized/de_patch/text/conversations/09_port_maje/09_cv_beach_landing.stringtable
@@ -225,7 +225,7 @@ Edér nickt in Richtung von etwas weiter drüben am Strand.</DefaultText>
     <Entry>
       <ID>43</ID>
       <DefaultText>[Dramatisch die Augen zusammenkneifen und auf den Ozean hinaus starren.] „Ich bin zurückgekehrt als der Herold von Berath. Ich habe die spezielle Mission, Eothas aufzuspüren und in Erfahrung zu bringen, was seine Pläne sind.“</DefaultText>
-      <FemaleText />
+      <FemaleText>[Dramatisch die Augen zusammenkneifen und auf den Ozean hinaus starren.] „Ich bin zurückgekehrt als Herold von Berath. Ich habe die spezielle Mission, Eothas aufzuspüren und in Erfahrung zu bringen, was seine Pläne sind.“</FemaleText>
     </Entry>
     <Entry>
       <ID>44</ID>

--- a/exported/localized/de_patch/text/conversations/16_wahaki_island/16_cv_wahaki_chief.stringtable
+++ b/exported/localized/de_patch/text/conversations/16_wahaki_island/16_cv_wahaki_chief.stringtable
@@ -1472,7 +1472,7 @@ Beim Gedanken daran verzieht sie das Gesicht.</DefaultText>
     <Entry>
       <ID>624</ID>
       <DefaultText>„Ich bin kein Spion. Ich bin der Herold von Berath.“</DefaultText>
-      <FemaleText>„Ich bin keine Spionin. Ich bin der Herold von Berath.“</FemaleText>
+      <FemaleText>„Ich bin keine Spionin. Ich bin Beraths Herold.“</FemaleText>
     </Entry>
     <Entry>
       <ID>626</ID>

--- a/exported/localized/de_patch/text/conversations/20_splintered_reef/20_cv_menzzago.stringtable
+++ b/exported/localized/de_patch/text/conversations/20_splintered_reef/20_cv_menzzago.stringtable
@@ -219,7 +219,7 @@ Nur die Totenblässe seiner Haut und der kaum erträgliche Verwesungsgeruch lass
     <Entry>
       <ID>90</ID>
       <DefaultText>„Ich bin der Herold von Berath.“</DefaultText>
-      <FemaleText />
+      <FemaleText>„Ich bin Beraths Herold.“</FemaleText>
     </Entry>
     <Entry>
       <ID>91</ID>
@@ -471,7 +471,7 @@ Er hebt seinen Stab, was die Kugel auf der nahegelegenen Plattform in einem krä
     <Entry>
       <ID>142</ID>
       <DefaultText>„Ich bin der Herold von Berath. Das muss doch etwas zählen.“</DefaultText>
-      <FemaleText />
+      <FemaleText>„Ich bin Beraths Herold. Das muss doch etwas zählen.“</FemaleText>
     </Entry>
     <Entry>
       <ID>143</ID>

--- a/exported/localized/de_patch/text/conversations/companions/companion_tekehu_intro.stringtable
+++ b/exported/localized/de_patch/text/conversations/companions/companion_tekehu_intro.stringtable
@@ -691,7 +691,7 @@ Tekēhu hebt eine Augenbraue.</DefaultText>
     <Entry>
       <ID>402</ID>
       <DefaultText>„Ich bin der Herold von Berath. Zumindest vorläufig.“</DefaultText>
-      <FemaleText />
+      <FemaleText>„Ich bin Beraths Herold. Zumindest vorläufig.“</FemaleText>
     </Entry>
     <Entry>
       <ID>403</ID>

--- a/exported/localized/de_patch/text/conversations/endgameslides.stringtable
+++ b/exported/localized/de_patch/text/conversations/endgameslides.stringtable
@@ -871,7 +871,7 @@ Doch jedes Ende verspricht einen Neuanfang. Als die Sonne über Ukaizo aufgeht, 
       <DefaultText>Als der Wächter von Caed Nua und der ehemalige Herold von Berath kehrst du zu deinem Schiff zurück und begibst dich auf die lange Heimreise.
 
 Du hoffst auf ruhiges Wetter.</DefaultText>
-      <FemaleText>Als Wächterin von Caed Nua und der ehemalige Herold von Berath kehrst du zu deinem Schiff zurück und begibst dich auf die lange Heimreise.
+      <FemaleText>Als Wächterin von Caed Nua und ehemals Beraths Herold kehrst du zu deinem Schiff zurück und begibst dich auf die lange Heimreise.
 
 Du hoffst auf ruhiges Wetter.</FemaleText>
     </Entry>

--- a/exported/localized/de_patch/text/conversations/endgameslides.stringtable
+++ b/exported/localized/de_patch/text/conversations/endgameslides.stringtable
@@ -501,7 +501,7 @@ Ohne Monarchen entwickelt sich die einst großartige Stadt Neketaka zu einem Ort
 
 Ihre erste und letzte Tat als Fürstin der antiken Stadt besteht darin, die Stürme von Ondras Turm wieder zu aktivieren. Nach getaner Arbeit sticht sie mit dem Fliegenden Henker in See.
 
-Sie bestimmt, dass keiner die Macht über Ukaizo ausüben soll. Unter ihr werden die Príncipi eine gesetzlose, wurzellose Piratenbande bleiben und das Todesfeuer allen offen stehen, die den Willen haben, sich dort durchzuschlagen.</DefaultText>
+Sie bestimmt, dass keiner die Macht über Ukaizo ausüben soll. Unter ihr werden die Príncipi eine gesetzlose, wurzellose Piratenbande bleiben und das Todesfeuer wird allen offen stehen, die den Willen haben, sich dort durchzuschlagen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -532,7 +532,7 @@ Die Stürme von Rauatai wüten weiter und die Menschen dort schlagen sich mit de
     </Entry>
     <Entry>
       <ID>89</ID>
-      <DefaultText>Indem du Ukaizo erreicht und Eothas gegenübergetreten bist, hast du das Unmögliche erreicht, und das sogar ohne Hilfe der großen Mächte des Todesfeuers. Deine Taten verdienen die Ehrfurcht und das Interesse einer Welt, die Helden mehr denn je braucht.
+      <DefaultText>Indem du Ukaizo erreicht hast und Eothas gegenübergetreten bist, hast du das Unmögliche erreicht, und das sogar ohne Hilfe der großen Mächte des Todesfeuers. Deine Taten verdienen die Ehrfurcht und das Interesse einer Welt, die Helden mehr denn je braucht.
 
 Manche sagen, dein Eingreifen hielt Eothas von einem weitaus schlimmeren Akt der Zerstörung ab. Viele glauben, &lt;i&gt;du&lt;/i&gt; wirst die Erlösung für Eora.</DefaultText>
       <FemaleText />
@@ -644,12 +644,12 @@ Viele, die herkamen, um ihr Glück zu finden, verlassen das Todesfeuer nun endg�
       <ID>108</ID>
       <DefaultText>Trotz anderer Spannungen im Archipel bleibt Port Maje ein Modell für die friedliche, produktive Kooperation zwischen den Huana und der Vailianischen Handelsgesellschaft.
 
-Auch wenn sie sich nicht immer einig sind, Gouverneur Clario und Sturmsprecher Ikawha arbeiten für den beiderseitigen Vorteil ihrer Völker zusammen.</DefaultText>
+Auch wenn sie sich nicht immer einig sind, Gouverneur Clario und Sturmsprecherin Ikawha arbeiten für den beiderseitigen Vorteil ihrer Völker zusammen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>109</ID>
-      <DefaultText>Als sich rauataianische Schiffe Port Maje nähern, schließen sich Gouverneur Clario und Sturmsprecher Ikawha zusammen, um Widerstand zu leisten.
+      <DefaultText>Als sich rauataianische Schiffe Port Maje nähern, schließen sich Gouverneur Clario und Sturmsprecherin Ikawha zusammen, um Widerstand zu leisten.
 
 Rauatai gewinnt schließlich die Oberhand, aber erst nach einem langen und harten Kampf.</DefaultText>
       <FemaleText />
@@ -768,7 +768,7 @@ Der führerlose Stamm nimmt Rauatais großzügige Hilfe gerne an. Sie erwidern d
       <ID>134</ID>
       <DefaultText>Nachdem der Adra von Poko Kohara wiederhergestellt wurde, errichtet Direktor Castol einen kleinen Hafen in Tikawara.
 
-Er schickt ein Team aus Beseelern, um die Ruinen und ihre Maschinen zu untersuchen. Es ist ein kleiner Betrieb, aber er bringt Stabilität und Wohlstand nach Tikawara und dessen Bewohnern.</DefaultText>
+Er schickt ein Team aus Beseelern, um die Ruinen und ihre Maschinen zu untersuchen. Es ist ein kleiner Betrieb, aber er bringt Stabilität und Wohlstand nach Tikawara und zu dessen Bewohnern.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -798,7 +798,7 @@ Zerrissen zwischen Abwarten und der Suche nach einer besseren Zukunft an einem a
       <ID>138</ID>
       <DefaultText>Nachdem der Adra in Poko Kohara zerstört wurde und damit auch die Hoffnungen auf einen Außenposten der Vailianer, entschließt sich der Stamm dazu, Tikawara zu verlassen.
 
-Klein und mobil wie er sind, erreicht der Stamm die Kua-o-Rikuhu-Inseln, wo er der Aufmerksamkeit größerer Mächte entgeht.</DefaultText>
+Klein und mobil wie er ist, erreicht der Stamm die Kua-o-Rikuhu-Inseln, wo er der Aufmerksamkeit größerer Mächte entgeht.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -819,7 +819,7 @@ Obwohl sie ihre Mauern mit Kanonen und ihre Häfen mit Schiffen verstärkt haben
 
 Leider ist ihre Flotte zu unorganisiert und die Sklavenhändler haben sich zu fest etabliert. Trotz zahlreicher kleiner Kämpfe im Laufe der Jahre gelingt es ihr nie, sie ganz auszulöschen.
 
-Aber ihre wilden Angriffe verhindern, dass die Krummsporn-Sache weiter expandiert.</DefaultText>
+Aber ihre wilden Angriffe verhindern, dass das Krummsporn-Geschäft weiter expandiert.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -852,7 +852,9 @@ Für eure verbleibende gemeinsame Zeit scheint Serafen – wenn nicht gerade gl�
       <DefaultText>Nachdem Pallegina ihren Vorgesetzten vom Handeln des Wächters gegen die Vailianische Handelsgesellschaft berichtet hat, wird sie zur Belohnung nach Hause in die Vailianischen Republiken versetzt. Die nächsten Jahre verbringt sie als Anführerin der Wache des Ducs von Ancenze.
 
 In dieser Rolle wird sie oft für ihren Mut und ihre Loyalität gelobt. Doch auch bei all dem Lob kann sie manchmal nicht anders, als zu denken, dass sie mehr Einfluss auf die Geschicke des Todesfeuers gehabt haben könnte.</DefaultText>
-      <FemaleText />
+      <FemaleText>Nachdem Pallegina ihren Vorgesetzten vom Handeln der Wächterin gegen die Vailianische Handelsgesellschaft berichtet hat, wird sie zur Belohnung nach Hause in die Vailianischen Republiken versetzt. Die nächsten Jahre verbringt sie als Anführerin der Wache des Ducs von Ancenze.
+
+In dieser Rolle wird sie oft für ihren Mut und ihre Loyalität gelobt. Doch auch bei all dem Lob kann sie manchmal nicht anders, als zu denken, dass sie mehr Einfluss auf die Geschicke des Todesfeuers gehabt haben könnte.</FemaleText>
     </Entry>
     <Entry>
       <ID>156</ID>
@@ -890,21 +892,21 @@ Er stirbt durch den Speer eines Kriegers, ohne jemals die ersehnten Antworten ge
 
 Nachdem das Rad zerbrochen wurde, denkt er, dass die Welt mehr denn je eine weise und verantwortungsvolle Führung braucht.
 
-Es ist ein vornehmes Ziel, und er erwartet nicht, dass er es zu Lebzeiten erreichen wird. Aber wenn er etwas von dem Wächter gelernt hat, dann dass auch eine einzige Person die Welt verändern kann.</DefaultText>
+Es ist ein vornehmes Ziel, und er erwartet nicht, dass er es zu Lebzeiten erreichen wird. Aber wenn er etwas von dem Wächter gelernt hat, dann, dass auch eine einzige Person die Welt verändern kann.</DefaultText>
       <FemaleText>Aloth erneuert seine Entschlossenheit, den Bleiernen Schlüssel von einem Werkzeug der Geheimhaltung und Unterdrückung in eine Überwachungsorganisation zu verwandeln.
 
 Nachdem das Rad zerbrochen wurde, denkt er, dass die Welt mehr denn je eine weise und verantwortungsvolle Führung braucht.
 
-Es ist ein vornehmes Ziel, und er erwartet nicht, dass er es zu Lebzeiten erreichen wird. Aber wenn er etwas von der Wächterin gelernt hat, dann dass auch eine einzige Person die Welt verändern kann.</FemaleText>
+Es ist ein vornehmes Ziel, und er erwartet nicht, dass er es zu Lebzeiten erreichen wird. Aber wenn er etwas von der Wächterin gelernt hat, dann, dass auch eine einzige Person die Welt verändern kann.</FemaleText>
     </Entry>
     <Entry>
       <ID>162</ID>
       <DefaultText>Aloth erneuert seine Entschlossenheit, den Bleiernen Schlüssel zu vernichten. Nachdem das Rad zerbrochen wurde, ist es dringender denn je, den Würgegriff der Götter auf die Gestandenen zu lockern.
 
-Es ist ein vornehmes Ziel, und er erwartet nicht, dass er es zu Lebzeiten erreichen wird. Aber wenn er etwas von dem Wächter gelernt hat, dann dass auch eine einzige Person die Welt verändern kann.</DefaultText>
+Es ist ein vornehmes Ziel, und er erwartet nicht, dass er es zu Lebzeiten erreichen wird. Aber wenn er etwas von dem Wächter gelernt hat, dann, dass auch eine einzige Person die Welt verändern kann.</DefaultText>
       <FemaleText>Aloth erneuert seine Entschlossenheit, den Bleiernen Schlüssel zu vernichten. Nachdem das Rad zerbrochen wurde, ist es dringender denn je, den Würgegriff der Götter auf die Gestandenen zu lockern.
 
-Es ist ein vornehmes Ziel, und er erwartet nicht, dass er es zu Lebzeiten erreichen wird. Aber wenn er etwas von der Wächterin gelernt hat, dann dass auch eine einzige Person die Welt verändern kann.</FemaleText>
+Es ist ein vornehmes Ziel, und er erwartet nicht, dass er es zu Lebzeiten erreichen wird. Aber wenn er etwas von der Wächterin gelernt hat, dann, dass auch eine einzige Person die Welt verändern kann.</FemaleText>
     </Entry>
     <Entry>
       <ID>163</ID>
@@ -934,7 +936,7 @@ Am besten hält er sich zurück und überlässt die Dinge ihrem Lauf.</DefaultTe
     </Entry>
     <Entry>
       <ID>168</ID>
-      <DefaultText>Wenn Aloth eins aus deinen Abenteuern gelernt hat, dann dass die Mächte, die die Welt formen, weitaus größer und komplexer sind, als er sich das je vorstellen konnte.
+      <DefaultText>Wenn Aloth eins aus deinen Abenteuern gelernt hat, dann, dass die Mächte, die die Welt formen, weitaus größer und komplexer sind, als er sich das je vorstellen konnte.
 
 Und sie liegen weit außerhalb der Kontrollmacht eines Einzelnen.</DefaultText>
       <FemaleText />
@@ -1056,7 +1058,7 @@ Kurz nach seiner Abreise aus Neketaka berichten Seeleute von berghohen Wassersku
       <ID>192</ID>
       <DefaultText>Die Entdeckung von Ukaizo bringt Tekēhu nicht die gesuchten Antworten, aber das erweist sich nur als kleiner Rückschlag.
 
-Allein das Wissen, dass Ngatis Auserwählten auf der Insel gelandet sind, entzündet etwas in den Huana–Stämmen – ein leidenschaftliches Verlangen, die Vergangenheit wiederherzustellen und sich den Weg in die Zukunft von der Geschichte weisen zu lassen.
+Allein das Wissen, dass Ngatis Auserwählte auf der Insel gelandet sind, entzündet etwas in den Huana–Stämmen – ein leidenschaftliches Verlangen, die Vergangenheit wiederherzustellen und sich den Weg in die Zukunft von der Geschichte weisen zu lassen.
 
 Tekēhu nutzt die Gunst der Stunde, gibt ein gutes Beispiel und lehrt sein Volk, sich aufeinander zu verlassen anstatt auf Omen. Seine Botschaft ist ein Umbruch der Normen, aber sie wird begrüßt und geliebt wie er.</DefaultText>
       <FemaleText />
@@ -1070,7 +1072,7 @@ Schon bald nach seiner Abreise aus Neketaka berichten entfernte Stämme von unge
     </Entry>
     <Entry>
       <ID>194</ID>
-      <DefaultText>Als sich eure Wege trennen, verabschiedet sich Tekēhu lang und energisch von dir. Er muss etwas in Todesfeuer erledigen, aber sein Herz – und, er besteht darauf, der Rest von ihm – gehören dir. Ihr versprecht einander, sich an einem anderen Ort einmal wiederzusehen.</DefaultText>
+      <DefaultText>Als sich eure Wege trennen, verabschiedet sich Tekēhu lang und energisch von dir. Er muss etwas in Todesfeuer erledigen, aber sein Herz – und, er besteht darauf, der Rest von ihm – gehören dir. Ihr versprecht einander, euch an einem anderen Ort einmal wiederzusehen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1113,16 +1115,16 @@ Die Kunst verschwindet nicht völlig, aber ihre Bedeutung schwindet.</DefaultTex
     </Entry>
     <Entry>
       <ID>204</ID>
-      <DefaultText>Er sagt dir Lebewohl, und schlägt dir vor, dass du dein nächstes Abenteuer in einem Bordell oder einer Schenke beginnst. Dort gibt man die Konsequenzen am Eingang ab.
+      <DefaultText>Er sagt dir Lebewohl und schlägt dir vor, dass du dein nächstes Abenteuer in einem Bordell oder einer Schenke beginnst. Dort gibt man die Konsequenzen am Eingang ab.
 
 Er scheint darauf erpicht zu sein, alte Konflikte hinter sich zu lassen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>205</ID>
-      <DefaultText>Nach etwas Abstand von der Marine gewinnt Maia Rua die Perspektive, wie Rauatai die Besetzung des Todesfeuers durchführte. Kaum, dass sie zum Einsatz zurückgekehrt ist, äußert sie ihre Frustration über einige eher hinterhältigen Taktiken, die sie im Namen des Heimatlandes miterlebte – und auch ausführte.
+      <DefaultText>Nach etwas Abstand von der Marine gewinnt Maia Rua die Perspektive, wie Rauatai die Besetzung des Todesfeuers durchführte. Kaum, dass sie zum Einsatz zurückgekehrt ist, äußert sie ihre Frustration über einige eher hinterhältige Taktiken, die sie im Namen des Heimatlandes miterlebte – und auch ausführte.
 
-Ihr Stimme dringt bis zum Ranga Nui vor, der seine Admiräle daran erinnert, dass Schlachten durch überlegene Taktiken gewonnen werden, aber der Krieg ist ein Kampf um Präzedenzfälle – und gewinnen ist nicht immer ein Sieg.
+Ihre Stimme dringt bis zum Ranga Nui vor, der seine Admiräle daran erinnert, dass Schlachten durch überlegene Taktiken gewonnen werden, aber der Krieg ist ein Kampf um Präzedenzfälle – und gewinnen ist nicht immer ein Sieg.
 
 Die Leute hören zu.</DefaultText>
       <FemaleText />
@@ -1159,7 +1161,7 @@ In der Zukunft wird sie als Heldin begrüßt.</DefaultText>
       <ID>212</ID>
       <DefaultText>Es bleibt euch nie genug Zeit, um eure Verbindung zu erkunden. Etwas an eurer Bindung fühlt sich unerledigt an, aber als sich eure Wege trennen, gehen euch langsam die Gründe aus, einander zu sehen.
 
-In deiner Gegenwart hat sie immer ein angenehmes Lächeln für dich und viele Fragen. Ihre Umarmung ist voller Wärme. Wenn jetzt dafür keine Zeit, dann vielleicht eines Tages.</DefaultText>
+In deiner Gegenwart hat sie immer ein angenehmes Lächeln für dich und viele Fragen. Ihre Umarmung ist voller Wärme. Wenn jetzt dafür keine Zeit ist, dann vielleicht eines Tages.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1217,16 +1219,16 @@ Auch wenn sein Blick größtenteils undurchschaubar ist, er ist ganz sicher nich
     </Entry>
     <Entry>
       <ID>222</ID>
-      <DefaultText>Deine Prüfungen im Todesfeuer enden, ohne dass du Serafens Wege ein zweites Mal kreuzt, und du erfährst nie, ob die Sklavenhändler, an die du ihn am Bleakrock-Schrein verkauft hast, ihn je gefangen haben. Auf jeden Fall will er wohl kaum noch etwas mit dir zu tun haben wollen.
+      <DefaultText>Deine Prüfungen im Todesfeuer enden, ohne dass du Serafens Wege ein zweites Mal kreuzt, und du erfährst nie, ob die Sklavenhändler, an die du ihn am Bleakrock-Schrein verkauft hast, ihn je gefangen haben. Auf jeden Fall wird er wohl kaum noch etwas mit dir zu tun haben wollen.
 
 Allerdings siehst du hin und wieder ein bisschen kobaltblau im Augenwinkel und dann fragst du dich, ob der Orlaner-Pirat mit dir so fertig ist wie du mit ihm.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>223</ID>
-      <DefaultText>Und dennoch, als ihr beide euch trennt, scheint Serafen ermutigt zu sein, gestärkt mit einem neuen Gefühl der Sinnhaftigkeit. Er lädt dich zu einem Drink ein, erhebt das Glas aufs Todesfeuer, sagt, sehen wir doch mal, ob wir nicht etwas aus dem verbliebenen Rest dieser Príncipi etwas machen können und setzt am nächsten Morgen die Segel.
+      <DefaultText>Und dennoch, als ihr beide euch trennt, scheint Serafen ermutigt zu sein, gestärkt mit einem neuen Gefühl der Sinnhaftigkeit. Er lädt dich zu einem Drink ein, erhebt das Glas aufs Todesfeuer, sagt, sehen wir doch mal, ob wir nicht etwas aus dem verbliebenen Rest dieser Príncipi machen können und setzt am nächsten Morgen die Segel.
 
-In den folgenden Jahren erreichen dich gelegentlich Gerüchte über einen blauen Orlaner-Piraten aus dem Todesfeuer, einem Freibeuter-Kapitän, der ebenso erpicht darauf ist, Sklaven zu befreien oder gegen fremden Einfluss zu kämpfen wie er gerne plündert und raubt.</DefaultText>
+In den folgenden Jahren erreichen dich gelegentlich Gerüchte über einen blauen Orlaner-Piraten aus dem Todesfeuer, einen Freibeuter-Kapitän, der ebenso erpicht darauf ist, Sklaven zu befreien oder gegen fremden Einfluss zu kämpfen wie er gerne plündert und raubt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1247,12 +1249,12 @@ Kurz danach verlässt dich Serafen. In den Jahren, die vergehen, hörst du hin u
       <ID>226</ID>
       <DefaultText>Nach eurer Begegnung mit Eothas öffnet er eine Flasche Rum, um aufs Überleben zu trinken. Schon nach kurzer Zeit entkorkt er eine zweite Flasche. Als Serafen schließlich Neketaka verlässt, hast du ihn schon wochenlang nicht mehr nüchtern gesehen.
 
-Der Orlaner gleitet so rätselhaft aus deinem Leben heraus, wie er reingeraten war, und das Wenige, das du in den kommenden Jahren über ihn hörst, lässt vermuten, dass er es sich in Schenken und Schankstuben heimischer fühlt als in Galeeren und Galeonen.</DefaultText>
+Der Orlaner gleitet so rätselhaft aus deinem Leben heraus, wie er hineingeraten war, und das Wenige, das du in den kommenden Jahren über ihn hörst, lässt vermuten, dass er es sich in Schenken und Schankstuben heimischer fühlt als in Galeeren und Galeonen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>227</ID>
-      <DefaultText>Serafen scheint von deiner Reise wenig beeinflusst. Ich wusste immer, dass die Götter größer sind als ich, sagt er dir an dem Abend, als er sich entschlossen hatte, sich von dir zu trennen. Zulange hat er diejenigen missachtet, die ihm am wichtigsten sind, gesteht er bei einer Flasche Rum, und er hat viele Ligen hinter sich gelassen, um das richtig zu stellen.
+      <DefaultText>Serafen scheint von deiner Reise wenig beeinflusst. Ich wusste immer, dass die Götter größer sind als ich, sagt er dir an dem Abend, als er sich entschlossen hatte, sich von dir zu trennen. Zu lange hat er diejenigen missachtet, die ihm am wichtigsten sind, gesteht er bei einer Flasche Rum, und er hat viele Meilen zu segeln, um das richtig zu stellen.
 
 Am nächsten Morgen ist er weg. Er hinterlässt nur eine einfache Strichmännchen-Zeichnung von Eothas am Schiffsrumpf, um zu zeigen: hier war ich.</DefaultText>
       <FemaleText />
@@ -1264,7 +1266,11 @@ Am nächsten Morgen ist er weg. Er hinterlässt nur eine einfache Strichmännche
 Während ihr durch das Todesfeuer reist, fällt dir auf, dass sie besser zu schlafen und öfter zu lachen scheint. Als die Zeit für sie gekommen ist, zu ihrem Tempel in Neketaka zurückzukehren, kann man ihr die Wehmut deutlich ansehen.
 
 Sie hinterlässt dir ihre Sichel und eine eilig zusammengekritzelte Notiz. Darauf steht. &lt;i&gt;Ein Andenken an einen Weg, den wir zusammen gingen. Vergiss mich nicht, Wächter. Denn ich werde für immer von dir träumen.&lt;/i&gt;</DefaultText>
-      <FemaleText />
+      <FemaleText>Als wäre sie von einem inneren Feuer angetrieben wendet sich Xoti genussvoll ihrem neuen Leben als Missionarin zu. Sie ist immer noch entschlossen, Seelen für Gaun zu ernten, aber nachdem sie ihre Ziele denen der anderen Dämmerungssterne angeglichen hat, strebt sie jetzt danach, den Lebenden genauso zu helfen wie den Toten.
+
+Während ihr durch das Todesfeuer reist, fällt dir auf, dass sie besser zu schlafen und öfter zu lachen scheint. Als die Zeit für sie gekommen ist, zu ihrem Tempel in Neketaka zurückzukehren, kann man ihr die Wehmut deutlich ansehen.
+
+Sie hinterlässt dir ihre Sichel und eine eilig zusammengekritzelte Notiz. Darauf steht. &lt;i&gt;Ein Andenken an einen Weg, den wir zusammen gingen. Vergiss mich nicht, Wächterin. Denn ich werde für immer von dir träumen.&lt;/i&gt;</FemaleText>
     </Entry>
     <Entry>
       <ID>229</ID>
@@ -1288,7 +1294,7 @@ Bis dahin bete sie für deine Sicherheit und widme sich ihren Pflichten gegenüb
     </Entry>
     <Entry>
       <ID>231</ID>
-      <DefaultText>Nachdem du Xoti um ihre Tugend beraubt hast, nimmt sie die Trennung nicht gut auf. An verschiedenen Nächten musst du sie wegschicken, weil sie versucht, dir in deine Kapitänsquartiere zu folgen.</DefaultText>
+      <DefaultText>Nachdem du Xoti ihrer Tugend beraubt hast, nimmt sie die Trennung nicht gut auf. In verschiedenen Nächten musst du sie wegschicken, weil sie versucht, dir in deine Kapitänsquartiere zu folgen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1386,7 +1392,11 @@ Die ganze Welt bebt, während der Adra in seinem Kern zerbricht.</DefaultText>
 Ohne zu zögern, nimmt sie sein Angebot an und verlangt, dass die Satzung der Frermàs mes Canc Suolias geändert werden möge, um zukünftig auch Frauen zuzulassen. Zu seinem Verdruss muss der Duc ihren Wunsch annehmen.
 
 Im nächsten Frühling nimmt die Bruderschaft die ersten fünf weiblichen Kadetten auf.</DefaultText>
-      <FemaleText />
+      <FemaleText>Weil sie der Wächterin dabei geholfen hat, Ukaizo für die Vailianische Handelsgesellschaft sicher zu stellen, wird Pallegina in einer Zeremonie in Biageppe geehrt, der alle fünf Duc-Bels beiwohnen. Duc Remasi ist so begeistert von seinem Glück, dass er Pallegina einen Wunsch gewährt.
+
+Ohne zu zögern, nimmt sie sein Angebot an und verlangt, dass die Satzung der Frermàs mes Canc Suolias geändert werden möge, um zukünftig auch Frauen zuzulassen. Zu seinem Verdruss muss der Duc ihren Wunsch annehmen.
+
+Im nächsten Frühling nimmt die Bruderschaft die ersten fünf weiblichen Kadetten auf.</FemaleText>
     </Entry>
     <Entry>
       <ID>247</ID>
@@ -1402,7 +1412,11 @@ Oft findet sie die Zeit, ihrem Camerata zu schreiben, und erzählt dir von den g
 Direktor Castol setzt sich für sie ein und betont ihre Mithilfe bei seiner Arbeit im Todesfeuer.
 
 Widerwillig lassen die Ducs Pallegina wieder in die Frermàs mes Canc Suolias. Sie verbleibt als die einzige offizielle Unterstützung der Ducs für Direktor Castol in der Region.</DefaultText>
-      <FemaleText />
+      <FemaleText>Weil sie der Wächterin dabei geholfen hat, Ukaizo für die Huana sicher zu stellen, wird Pallegina sofort aus der Bruderschaft entlassen, aber die Ducs verbannen sie nicht aus den Republiken.
+
+Direktor Castol setzt sich für sie ein und betont ihre Mithilfe bei seiner Arbeit im Todesfeuer.
+
+Widerwillig lassen die Ducs Pallegina wieder in die Frermàs mes Canc Suolias. Sie verbleibt als die einzige offizielle Unterstützung der Ducs für Direktor Castol in der Region.</FemaleText>
     </Entry>
     <Entry>
       <ID>249</ID>
@@ -1411,7 +1425,11 @@ Widerwillig lassen die Ducs Pallegina wieder in die Frermàs mes Canc Suolias. S
 Da sie keine weitere Unterstützung von der Vailianischen Handelsgesellschaft erhält, wird sie aus den Republiken verbannt.
 
 Verstoßen von ihrem eigenen Volk und von den Huana als Vailianerin verachtet stellt sich das Todesfeuer für sie als kalt und unwirtlich heraus. Mit gebrochenem Willen geht sie schließlich an Bord eines Schiffes, das in Richtung Trutzbucht segelt, und verschwindet.</DefaultText>
-      <FemaleText />
+      <FemaleText>Weil sie der Wächterin dabei geholfen hat, Ukaizo für die Huana sicherzustellen, wird Pallegina sofort aus der Bruderschaft entlassen.
+
+Da sie keine weitere Unterstützung von der Vailianischen Handelsgesellschaft erhält, wird sie aus den Republiken verbannt.
+
+Verstoßen von ihrem eigenen Volk und von den Huana als Vailianerin verachtet stellt sich das Todesfeuer für sie als kalt und unwirtlich heraus. Mit gebrochenem Willen geht sie schließlich an Bord eines Schiffes, das in Richtung Trutzbucht segelt, und verschwindet.</FemaleText>
     </Entry>
     <Entry>
       <ID>250</ID>
@@ -1420,7 +1438,11 @@ Verstoßen von ihrem eigenen Volk und von den Huana als Vailianerin verachtet st
 Eine Zeit lang posieren sie demonstrativ damit, sie aus dem Orden zu verbannen, aber ihnen wird schnell klar, dass Kapitän Furrante nicht beabsichtigt, die Gesellschaft aus dem Todesfeuer zu drängen.
 
 Innerhalb weniger Monate wird sie wieder in die Bruderschaft eingegliedert, auch wenn die Ducs sicherstellen, dass sie im darauffolgenden Jahr ausschließlich für die unangenehmsten Arbeiten eingeteilt wird.</DefaultText>
-      <FemaleText />
+      <FemaleText>Da Pallegina der Wächterin dabei geholfen hat, Ukaizo für die Príncipi zu beanspruchen, ist die Vailianische Handelsgesellschaft zunächst wütend.
+
+Eine Zeit lang posieren sie demonstrativ damit, sie aus dem Orden zu verbannen, aber ihnen wird schnell klar, dass Kapitän Furrante nicht beabsichtigt, die Gesellschaft aus dem Todesfeuer zu drängen.
+
+Innerhalb weniger Monate wird sie wieder in die Bruderschaft eingegliedert, auch wenn die Ducs sicherstellen, dass sie im darauffolgenden Jahr ausschließlich für die unangenehmsten Arbeiten eingeteilt wird.</FemaleText>
     </Entry>
     <Entry>
       <ID>251</ID>
@@ -1431,7 +1453,13 @@ Ihre Wut intensiviert sich, als Aeldys’ Piraten ihre Angriffe auf alle Handels
 Anstatt Pallegina aus der Bruderschaft zu entfernen, betrauen die Ducs sie damit, die anfälligsten Schiffe in der Flotte der Gesellschaft zu bewachen.
 
 Fünf Monate nach ihrer Ernennung geht Pallegina mit der Vengiatta men Aimora unter. Ihre Leiche wird nie gefunden.</DefaultText>
-      <FemaleText />
+      <FemaleText>Da Pallegina der Wächterin dabei geholfen hat, Ukaizo für die Príncipi zu beanspruchen, ist die Vailianische Handelsgesellschaft wütend.
+
+Ihre Wut intensiviert sich, als Aeldys’ Piraten ihre Angriffe auf alle Handelsschiffe im Todesfeuer verdreifachen.
+
+Anstatt Pallegina aus der Bruderschaft zu entfernen, betrauen die Ducs sie damit, die anfälligsten Schiffe in der Flotte der Gesellschaft zu bewachen.
+
+Fünf Monate nach ihrer Ernennung geht Pallegina mit der Vengiatta men Aimora unter. Ihre Leiche wird nie gefunden.</FemaleText>
     </Entry>
     <Entry>
       <ID>252</ID>
@@ -1440,7 +1468,11 @@ Fünf Monate nach ihrer Ernennung geht Pallegina mit der Vengiatta men Aimora un
 In dem darauf folgenden Chaos betrachtet die Gesellschaft die Handlungen Palleginas nuancierter. Der Aufruhr in der Region erlaubt es der gut organisierten Gesellschaft, eine Anzahl wertvoller Güter von ihren Konkurrenten zu erbeuten.
 
 Auch wenn Pallegina für ihre Taten nicht belohnt wird, so wird sie doch ebenfalls nicht bestraft. Die Ducs und die Songretta vereinbaren, ihre Unterstützung des Wächters zu „vergessen“. Sie wird still und leise wieder von den Vailianischen Republiken in die Pflicht genommen, ein Befehl, den sie gerne befolgt.</DefaultText>
-      <FemaleText />
+      <FemaleText>Die Vailianische Handelsgesellschaft ist anfangs wütend, als sie erfährt, dass Pallegina der Wächterin bei der Einnahme von Ukaizo geholfen hatte.
+
+In dem darauf folgenden Chaos betrachtet die Gesellschaft die Handlungen Palleginas nuancierter. Der Aufruhr in der Region erlaubt es der gut organisierten Gesellschaft, eine Anzahl wertvoller Güter von ihren Konkurrenten zu erbeuten.
+
+Auch wenn Pallegina für ihre Taten nicht belohnt wird, so wird sie doch ebenfalls nicht bestraft. Die Ducs und die Songretta vereinbaren, ihre Unterstützung der Wächterin zu „vergessen“. Sie wird still und leise wieder von den Vailianischen Republiken in die Pflicht genommen, ein Befehl, den sie gerne befolgt.</FemaleText>
     </Entry>
     <Entry>
       <ID>255</ID>
@@ -1465,14 +1497,20 @@ Ihre Brüder und sogar die Ducs selbst bemerken, dass Palleginas an den Tagen, a
 Sie verfluchte sich selbst, dass sie ihren Freund nicht eher gefunden hat, dass sie ihn nicht vor Kapitän Tatzatl und seiner Mannschaft beschützt hat.
 
 Während einiger einsamer Nächte verfasst Pallegina Briefe an den Wächter, in denen sie fragt, was sie noch hätten tun können, um ihn zu retten. Sie werden nie abgeschickt.</DefaultText>
-      <FemaleText />
+      <FemaleText>Trotz ihres Glücks im Todesfeuer trauert Pallegina jahrelang um Giacolo.
+
+Sie verfluchte sich selbst, dass sie ihren Freund nicht eher gefunden hat, dass sie ihn nicht vor Kapitän Tatzatl und seiner Mannschaft beschützt hat.
+
+Während einiger einsamer Nächte verfasst Pallegina Briefe an die Wächterin, in denen sie fragt, was sie noch hätten tun können, um ihn zu retten. Sie werden nie abgeschickt.</FemaleText>
     </Entry>
     <Entry>
       <ID>258</ID>
       <DefaultText>Auch wenn sie ihr zweites Abenteuer mit dem Wächter überstanden hat, bedauert Pallegina, dass sie Giacolo, ihren alten Freund aus Kindertagen, nie gefunden hat.
 
 Sie sucht überall, im Todesfeuer und darüber hinaus, findet ihn aber nie.</DefaultText>
-      <FemaleText />
+      <FemaleText>Auch wenn sie ihr zweites Abenteuer mit der Wächterin überstanden hat, bedauert Pallegina, dass sie Giacolo, ihren alten Freund aus Kindertagen, nie gefunden hat.
+
+Sie sucht überall, im Todesfeuer und darüber hinaus, findet ihn aber nie.</FemaleText>
     </Entry>
     <Entry>
       <ID>261</ID>
@@ -1495,7 +1533,11 @@ Deine Lungen beginnen zu brennen. In der Ferne siehst du, wie ein mattes Licht a
 &lt;i&gt;Wir hatten große Hoffnungen für dich, Wächter von Caed Nua.&lt;/i&gt;
 
 Dein Körper verrät dich und schluckt ziemlich viel Salzwasser. Deine Brust verkrampft sich. Der Schmerz ist unerträglich.</DefaultText>
-      <FemaleText />
+      <FemaleText>Das Licht erreicht dich. Es ist an einem größeren Seeteufel befestigt, dessen Schuppen in der Dunkelheit glänzen. Der Gesang der Frau hört auf, als die Stimme zu deinem Geist spricht.
+
+&lt;i&gt;Wir hatten große Hoffnungen für dich, Wächterin von Caed Nua.&lt;/i&gt;
+
+Dein Körper verrät dich und schluckt ziemlich viel Salzwasser. Deine Brust verkrampft sich. Der Schmerz ist unerträglich.</FemaleText>
     </Entry>
     <Entry>
       <ID>264</ID>

--- a/exported/localized/de_patch/text/conversations/re_scripted_interactions/re_si_crew_event_captain_personality.stringtable
+++ b/exported/localized/de_patch/text/conversations/re_scripted_interactions/re_si_crew_event_captain_personality.stringtable
@@ -193,7 +193,7 @@ Du wendest dich von ihnen ab und stolzierst in dein Quartier zurück.</DefaultTe
     <Entry>
       <ID>31</ID>
       <DefaultText>„Diese Augen haben den Schleier des Todes enthüllt; und doch bin ich, Herold von Berath und Vollstrecker ihres Willens, zurückgekehrt.“</DefaultText>
-      <FemaleText />
+      <FemaleText>„Diese Augen haben den Schleier des Todes enthüllt; und doch bin ich, Herold von Berath und Vollstreckerin ihres Willens, zurückgekehrt.“</FemaleText>
     </Entry>
     <Entry>
       <ID>32</ID>

--- a/exported/localized/de_patch/text/conversations/re_scripted_interactions/re_si_mid_ukaizo_gods.stringtable
+++ b/exported/localized/de_patch/text/conversations/re_scripted_interactions/re_si_mid_ukaizo_gods.stringtable
@@ -389,7 +389,9 @@ Er führt dich am Ende in das Reich Beraths, zu der kalten Plattform und dem Rau
       <DefaultText>„Schon bald wirst du Eothas zum wahrscheinlich letzten Mal gegenübertreten. Du wirst dies als der Herold von Berath tun, dem einzigen Geschöpf auf Eora, auf welches er hören wird.“
 
 „Denke daran.“</DefaultText>
-      <FemaleText />
+      <FemaleText>„Schon bald wirst du Eothas zum wahrscheinlich letzten Mal gegenübertreten. Du wirst dies als Herold von Berath tun, dem einzigen Geschöpf auf Eora, auf welches er hören wird.“
+
+„Denke daran.“</FemaleText>
     </Entry>
     <Entry>
       <ID>325</ID>

--- a/exported/localized/de_patch/text/conversations/re_scripted_interactions/re_si_post_hasongo_gods.stringtable
+++ b/exported/localized/de_patch/text/conversations/re_scripted_interactions/re_si_post_hasongo_gods.stringtable
@@ -316,7 +316,7 @@
     <Entry>
       <ID>114</ID>
       <DefaultText>„Du magst ja der Wächter von Caed Nua sein, der Hund von Eothas und der Herold von Berath – aber du bist und bleibst ein sterblicher Mann.“</DefaultText>
-      <FemaleText>„Du magst ja die Wächterin von Caed Nua sein, die Hündin von Eothas und der Herold von Berath – aber du bist und bleibst eine sterbliche Frau.“</FemaleText>
+      <FemaleText>„Du magst ja die Wächterin von Caed Nua sein, die Hündin von Eothas und Herold von Berath – aber du bist und bleibst eine sterbliche Frau.“</FemaleText>
     </Entry>
     <Entry>
       <ID>116</ID>

--- a/exported/localized/de_patch/text/conversations/re_scripted_interactions/re_si_post_magransteeth_gods-2.stringtable
+++ b/exported/localized/de_patch/text/conversations/re_scripted_interactions/re_si_post_magransteeth_gods-2.stringtable
@@ -421,7 +421,7 @@ Die Vögel verweilen schließlich zu lange, und Magran scheucht sie davon. Sie e
     <Entry>
       <ID>190</ID>
       <DefaultText>„Bereite dich vor, Wächter“, sagt Hylea. „Der Hüter wird nicht beiseite treten, nicht einmal für den Herold von Berath.“</DefaultText>
-      <FemaleText>„Bereite dich vor, Wächterin“, sagt Hylea. „Der Hüter wird nicht beiseite treten, nicht einmal für den Herold von Berath.“</FemaleText>
+      <FemaleText>„Bereite dich vor, Wächterin“, sagt Hylea. „Der Hüter wird nicht beiseite treten, nicht einmal für Beraths Herold.“</FemaleText>
     </Entry>
     <Entry>
       <ID>191</ID>

--- a/lax1_exported/localized/de_patch/text/conversations/lax01_00_arena_island/lax01_00_cv_aexica.stringtable
+++ b/lax1_exported/localized/de_patch/text/conversations/lax01_00_arena_island/lax01_00_cv_aexica.stringtable
@@ -762,7 +762,7 @@ Pallegina spöttelt und zersaust ihre Federn.</DefaultText>
     </Entry>
     <Entry>
       <ID>252</ID>
-      <DefaultText>„Erwähnte nicht der Drache Neriscyrlas etwas Ähnliches?“</DefaultText>
+      <DefaultText>„Erwähnte nicht die Drachin Neriscyrlas etwas Ähnliches?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax1_exported/localized/de_patch/text/conversations/lax01_00_arena_island/lax01_00_cv_boar_druids.stringtable
+++ b/lax1_exported/localized/de_patch/text/conversations/lax01_00_arena_island/lax01_00_cv_boar_druids.stringtable
@@ -446,7 +446,7 @@ Hateno reibt sein Kinn und grunzt dann endlich zustimmend.</DefaultText>
     <Entry>
       <ID>120</ID>
       <DefaultText>„Ich bin der Herold von Berath.“</DefaultText>
-      <FemaleText />
+      <FemaleText>„Ich bin Beraths Herold.“</FemaleText>
     </Entry>
     <Entry>
       <ID>121</ID>

--- a/lax1_exported/localized/de_patch/text/conversations/lax01_00_arena_island/lax01_00_cv_prefightbanter_slayers.stringtable
+++ b/lax1_exported/localized/de_patch/text/conversations/lax01_00_arena_island/lax01_00_cv_prefightbanter_slayers.stringtable
@@ -150,7 +150,7 @@ Der Krieger salutiert mit einem schiefen Lächeln, während er und seine Truppe 
     </Entry>
     <Entry>
       <ID>29</ID>
-      <DefaultText>„Ich habe Neriscyrlas getötet, den untoten Drachen auf der Toten Scholle. Hab ihn sogar mehrere Male getötet.“</DefaultText>
+      <DefaultText>„Ich habe Neriscyrlas getötet, die untote Drachin auf der Toten Scholle. Hab sie sogar mehrere Male getötet.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -450,7 +450,7 @@ Er dreht sich um, wirft dabei seinen Umhang theatralisch in die Luft und schreit
     </Entry>
     <Entry>
       <ID>103</ID>
-      <DefaultText>„Ich hätte beinahe Neriscyrlas getötet, den Leichendrachen der toten Scholle, aber er ist weggeflogen.“</DefaultText>
+      <DefaultText>„Ich hätte beinahe Neriscyrlas getötet, die Leichendrachin der toten Scholle, aber sie ist weggeflogen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax1_exported/localized/de_patch/text/conversations/lax01_00_arena_island/lax01_00_poi_bs_slayer.stringtable
+++ b/lax1_exported/localized/de_patch/text/conversations/lax01_00_arena_island/lax01_00_poi_bs_slayer.stringtable
@@ -261,7 +261,7 @@
     </Entry>
     <Entry>
       <ID>73</ID>
-      <DefaultText>„Einer von denen wurde zu Neriscyrlas?“</DefaultText>
+      <DefaultText>„Eine von denen wurde zu Neriscyrlas?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax2_exported/localized/de_patch/text/conversations/23_vtc_between/23_cv_rymrgand.stringtable
+++ b/lax2_exported/localized/de_patch/text/conversations/23_vtc_between/23_cv_rymrgand.stringtable
@@ -53,7 +53,7 @@
     </Entry>
     <Entry>
       <ID>142</ID>
-      <DefaultText>„Ich habe diesen Drachen für dich getötet. Reicht das nicht?“</DefaultText>
+      <DefaultText>„Ich habe diese Drachin für dich getötet. Reicht das nicht?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_01_cv_dracolich.stringtable
+++ b/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_01_cv_dracolich.stringtable
@@ -6,16 +6,16 @@
   <Entries>
     <Entry>
       <ID>1</ID>
-      <DefaultText>Der Drache – besser gesagt, diese verweste Hülle in Form eines Drachen – richtet eines seiner leuchtenden Augen auf dich. Du spürst, wie sein Blick auf deine Seele fällt und deinen Geist ausspäht.
+      <DefaultText>Die Drachin – besser gesagt, diese verweste Hülle in Form eines Drachen – richtet eines ihrer leuchtenden Augen auf dich. Du spürst, wie ihr Blick auf deine Seele fällt und deinen Geist ausspäht.
 
-Ein tiefes Grummeln steigt aus dem Schlund des Drachen empor. Es klingt bedrohlich, wird jedoch nicht zu Worten.</DefaultText>
+Ein tiefes Grummeln steigt aus dem Schlund der Drachin empor. Es klingt bedrohlich, wird jedoch nicht zu Worten.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>2</ID>
-      <DefaultText>Der Drache – besser gesagt, diese verweste Hülle in Form eines Drachen –, nimmt dich nicht wahr, bis du direkt vor ihm bist. Dann dreht er seinen Kopf mit einem wilden Schnauben zu dir um und violett leuchtende Flammen kommen aus seiner Nase.
+      <DefaultText>Die Drachin – besser gesagt, diese verweste Hülle in Form eines Drachen –, nimmt dich nicht wahr, bis du direkt vor ihr bist. Dann dreht sir ihren Kopf mit einem wilden Schnauben zu dir um und violett leuchtende Flammen kommen aus ihrer Nase.
 
-Du spürst, wie sein Blick auf deine Seele fällt und deinen Geist ausspäht.</DefaultText>
+Du spürst, wie ihr Blick auf deine Seele fällt und deinen Geist ausspäht.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -50,12 +50,12 @@ Du spürst, wie sein Blick auf deine Seele fällt und deinen Geist ausspäht.</D
     </Entry>
     <Entry>
       <ID>10</ID>
-      <DefaultText>Der Drache verlagert sein Gewicht und zermalmt Schnee unter den Klauen seiner Füße, als er sich zu dir umdreht. Du kannst sein Gelächter am Rand deiner Gedanken hören.</DefaultText>
+      <DefaultText>Die Drachin verlagert ihr Gewicht und zermalmt Schnee unter den Klauen ihrer Füße, als sie sich zu dir umdreht. Du kannst ihr Gelächter am Rand deiner Gedanken hören.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>11</ID>
-      <DefaultText>Der Drache verlagert sein Gewicht und zermalmt Schnee und Eis unter den Klauen seiner Füße, als er sich zu dir umdreht.</DefaultText>
+      <DefaultText>Die Drachin verlagert ihr Gewicht und zermalmt Schnee und Eis unter den Klauen ihrer Füße, als sie sich zu dir umdreht.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_01_cv_hafjorn_confront.stringtable
+++ b/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_01_cv_hafjorn_confront.stringtable
@@ -16,7 +16,7 @@
     </Entry>
     <Entry>
       <ID>4</ID>
-      <DefaultText>„Euer Priester hier ist ein ungläubiger Feigling, der sich versteckte, als der Drache auftauchte.“</DefaultText>
+      <DefaultText>„Euer Priester hier ist ein ungläubiger Feigling, der sich versteckte, als die Drachin auftauchte.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -61,7 +61,7 @@
     </Entry>
     <Entry>
       <ID>14</ID>
-      <DefaultText>„Euer Priester hier ist ein ungläubiger Feigling, der sich versteckte, als der Drache auftauchte.“</DefaultText>
+      <DefaultText>„Euer Priester hier ist ein ungläubiger Feigling, der sich versteckte, als die Drachin auftauchte.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -112,7 +112,7 @@ Die verhüllte Gestalt sieht dich mit verschränkten Armen finster an. Glaubst d
     </Entry>
     <Entry>
       <ID>23</ID>
-      <DefaultText>„Er hat euch glauben lassen, dass der Drache da draußen ein erwählter Vorbote Rymrgands sei. Und jetzt ist er tot.“</DefaultText>
+      <DefaultText>„Er hat euch glauben lassen, dass die Drachin da draußen ein erwählter Vorbote Rymrgands sei. Und jetzt ist er tot.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -164,12 +164,12 @@ Sein verhüllter Kopf wendet sich von Vatnir zu dir und dann wieder zurück.</De
     </Entry>
     <Entry>
       <ID>33</ID>
-      <DefaultText>„Rymrgand hat Vatnir aufgetragen, mir bei der Untersuchung dieses Drachens zu helfen.“</DefaultText>
+      <DefaultText>„Rymrgand hat Vatnir aufgetragen, mir bei der Untersuchung dieser Drachin zu helfen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>34</ID>
-      <DefaultText>„Ich habe ihn gebeten, mir zu helfen, die Wahrheit über diesen Drachen herauszufinden. Er hat zugestimmt.“</DefaultText>
+      <DefaultText>„Ich habe ihn gebeten, mir zu helfen, die Wahrheit über diese Drachin herauszufinden. Er hat zugestimmt.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -343,7 +343,7 @@ Mit einem Seufzen sackt Hafjórn in sich zusammen.</DefaultText>
     </Entry>
     <Entry>
       <ID>71</ID>
-      <DefaultText>„Er hat euch glauben lassen, dass der Drache da draußen ein erwählter Vorbote Rymrgands sei. Und jetzt ist er tot.“</DefaultText>
+      <DefaultText>„Er hat euch glauben lassen, dass die Drachin da draußen ein erwählter Vorbote Rymrgands sei. Und jetzt ist er tot.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_01_cv_harbinger_leader.stringtable
+++ b/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_01_cv_harbinger_leader.stringtable
@@ -211,12 +211,12 @@ Vatnir zeigt zum Eingang der Zuflucht.</DefaultText>
     </Entry>
     <Entry>
       <ID>40</ID>
-      <DefaultText>„Das … ist gut. Dass er tot ist. Er hat die Wacht schon jahrelang geplagt. Aber die Leute sind weiterhin gekommen. Und er hat immer weiter … gefressen.“</DefaultText>
+      <DefaultText>„Das … ist gut. Dass sie tot ist. Sie hat die Wacht schon jahrelang geplagt. Aber die Leute sind weiterhin gekommen. Und sie hat immer weiter … gefressen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>41</ID>
-      <DefaultText>„Jedes Mal, wenn er erscheint, breitet sich das Eis weiter aus. Ich … Ich weiß nicht, wie ich dem ein Ende setzen soll. Also habe ich dir geschrieben.“</DefaultText>
+      <DefaultText>„Jedes Mal, wenn sie erscheint, breitet sich das Eis weiter aus. Ich … Ich weiß nicht, wie ich dem ein Ende setzen soll. Also habe ich dir geschrieben.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -226,7 +226,7 @@ Vatnir zeigt zum Eingang der Zuflucht.</DefaultText>
     </Entry>
     <Entry>
       <ID>43</ID>
-      <DefaultText>„Ich weiß nicht, was ich dir sagen soll. Es ist ein Drache. Oder sieht zumindest so aus. Und er ist so verwest, dass es mir logisch erschien, ihn mit dem Gott des Verfalls in Verbindung zu bringen.“</DefaultText>
+      <DefaultText>„Ich weiß nicht, was ich dir sagen soll. Es ist eine Drachin. Oder sieht zumindest so aus. Und sie ist so verwest, dass es mir logisch erschien, sie mit dem Gott des Verfalls in Verbindung zu bringen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1171,7 +1171,7 @@ Er kichert, auch wenn das Geräusch sich in eine Reihe dicker, feucht klingender
     </Entry>
     <Entry>
       <ID>240</ID>
-      <DefaultText>„Der Drache stellt die unmittelbarste Bedrohung dar.“</DefaultText>
+      <DefaultText>„Die Drachin stellt die unmittelbarste Bedrohung dar.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1181,7 +1181,7 @@ Er kichert, auch wenn das Geräusch sich in eine Reihe dicker, feucht klingender
     </Entry>
     <Entry>
       <ID>242</ID>
-      <DefaultText>„Der Drache ist es.“</DefaultText>
+      <DefaultText>„Die Drachin ist es.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_01_cv_huana_wandering_soul.stringtable
+++ b/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_01_cv_huana_wandering_soul.stringtable
@@ -91,7 +91,7 @@ Er atmet schwer und stotternd aus und kann dir nicht wirklich in die Augen sehen
     </Entry>
     <Entry>
       <ID>22</ID>
-      <DefaultText>„Du könntest dich wieder reinwaschen. Hilf mir, den Drachen Neriscyrlas zu besiegen.“</DefaultText>
+      <DefaultText>„Du könntest dich wieder reinwaschen. Hilf mir, die Drachin Neriscyrlas zu besiegen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -106,7 +106,7 @@ Er atmet schwer und stotternd aus und kann dir nicht wirklich in die Augen sehen
     </Entry>
     <Entry>
       <ID>25</ID>
-      <DefaultText>„Ein Sieg gegen den Drachen würde meinem Reich Ruhm bringen. Vielleicht … Vielleicht könnten wir gemeinsam auch mein Vermächtnis reparieren.“</DefaultText>
+      <DefaultText>„Ein Sieg gegen die Drachin würde meinem Reich Ruhm bringen. Vielleicht … Vielleicht könnten wir gemeinsam auch mein Vermächtnis reparieren.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -961,7 +961,7 @@ Tekēhu seufzt und dreht sich zurückhaltend dem König zu.</DefaultText>
     </Entry>
     <Entry>
       <ID>264</ID>
-      <DefaultText>„Du hilfst mir, diesen Drachen zu bekämpfen oder ich verstreue deine Seele im Nichts!“</DefaultText>
+      <DefaultText>„Du hilfst mir, diese Drachin zu bekämpfen oder ich verstreue deine Seele im Nichts!“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1007,12 +1007,12 @@ Tekēhu verschränkt die Arme und seufzt durch die Nase.</DefaultText>
     </Entry>
     <Entry>
       <ID>275</ID>
-      <DefaultText>„Ein Sieg gegen den Drachen würde meinem Reich Ruhm bringen. Vielleicht … Vielleicht könnten wir gemeinsam auch mein Vermächtnis reparieren.“</DefaultText>
+      <DefaultText>„Ein Sieg gegen die Drachin würde meinem Reich Ruhm bringen. Vielleicht … Vielleicht könnten wir gemeinsam auch mein Vermächtnis reparieren.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>276</ID>
-      <DefaultText>„Die Bestie ist gefühlskalt, grausam … Aber die Priester sagen, dass er nicht lügt.“</DefaultText>
+      <DefaultText>„Die Bestie ist gefühlskalt, grausam … Aber die Priester sagen, dass sie nicht lügt.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1190,7 +1190,7 @@ Der König wendet sich von dir ab, seine Augen sind feucht.</DefaultText>
     </Entry>
     <Entry>
       <ID>345</ID>
-      <DefaultText>[Prinz Edanke nachsprechen.] „Du hättest unser Königreich nicht retten können, aber du kannst dich wieder reinwaschen. Hilf mir, den Drachen Neriscyrlas zu bekämpfen.“</DefaultText>
+      <DefaultText>[Prinz Edanke nachsprechen.] „Du hättest unser Königreich nicht retten können, aber du kannst dich wieder reinwaschen. Hilf mir, die Drachin Neriscyrlas zu bekämpfen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_01_cv_hw_resolution.stringtable
+++ b/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_01_cv_hw_resolution.stringtable
@@ -56,7 +56,7 @@
     </Entry>
     <Entry>
       <ID>19</ID>
-      <DefaultText>„Es war Rymrgands Wille, dass der Drache, der uns bedrohte, ausgesandt werden sollte und so war es auch!“
+      <DefaultText>„Es war Rymrgands Wille, dass die Drachin, die uns bedrohte, ausgesandt werden sollte und so war es auch!“
 
 Ein paar der Boten sehen sich verwirrt an, aber Vatnir fährt fort.</DefaultText>
       <FemaleText />
@@ -103,12 +103,12 @@ Ein paar der Boten sehen sich verwirrt an, aber Vatnir fährt fort.</DefaultText
     </Entry>
     <Entry>
       <ID>28</ID>
-      <DefaultText>„Du … wirklich? Mit der Bestie des Winters selbst? Und der Drache? Was ist aus dem Drachen geworden?“</DefaultText>
+      <DefaultText>„Du … wirklich? Mit der Bestie des Winters selbst? Und die Drachin? Was ist aus der Drachin geworden?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>29</ID>
-      <DefaultText>„Der Drache kommt nicht zurück. Das ist alles, was du wissen musst.“</DefaultText>
+      <DefaultText>„Die Drachin kommt nicht zurück. Das ist alles, was du wissen musst.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -140,7 +140,7 @@ Mit gesenktem Kopf beten die Boten zur Bestie des Winters.</DefaultText>
     </Entry>
     <Entry>
       <ID>37</ID>
-      <DefaultText>„Rymrgand braucht dich hier nicht und der Drache war nicht sein Vorbote. Du solltest diesen Ort wahrscheinlich verlassen.“</DefaultText>
+      <DefaultText>„Rymrgand braucht dich hier nicht und die Drachin war nicht sein Vorbote. Du solltest diesen Ort wahrscheinlich verlassen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -164,7 +164,7 @@ Mit gesenktem Kopf beten die Boten zur Bestie des Winters.</FemaleText>
     </Entry>
     <Entry>
       <ID>41</ID>
-      <DefaultText>„Das ist … nun, es ist unfassbar. Fast unglaublich. Und Rymrgands Vorbote? Was ist aus dem Drachen geworden?“</DefaultText>
+      <DefaultText>„Das ist … nun, es ist unfassbar. Fast unglaublich. Und Rymrgands Vorbote? Was ist aus der Drachin geworden?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -491,7 +491,7 @@ Der mit einer Kapuze verhüllte Elf wendet sich von dir ab und schließt sich se
     </Entry>
     <Entry>
       <ID>110</ID>
-      <DefaultText>„Aber … Der Drache ist der Vorbote, oder? Bruder Vatnir … du warst dort. Was hast du gesehen?“</DefaultText>
+      <DefaultText>„Aber … Die Drachin ist der Vorbote, oder? Bruder Vatnir … du warst dort. Was hast du gesehen?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_01_si_icebergbreach_rymrgand.stringtable
+++ b/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_01_si_icebergbreach_rymrgand.stringtable
@@ -6,7 +6,7 @@
   <Entries>
     <Entry>
       <ID>1</ID>
-      <DefaultText>Du steht vor dem leuchtenden Portal, das den Drachen verschlungen hat. Aus der Nähe siehst du, dass es sich um einen gezackten Riss in der Welt handelt.</DefaultText>
+      <DefaultText>Du steht vor dem leuchtenden Portal, das die Drachin verschlungen hat. Aus der Nähe siehst du, dass es sich um einen gezackten Riss in der Welt handelt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -23,7 +23,7 @@ Es ist die Manifestation von Rymrgand.</DefaultText>
     </Entry>
     <Entry>
       <ID>4</ID>
-      <DefaultText>„Was ist mit dem Drachen geschehen?“</DefaultText>
+      <DefaultText>„Was ist mit der Drachin geschehen?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_01_si_icebergexterior_wallclimb.stringtable
+++ b/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_01_si_icebergexterior_wallclimb.stringtable
@@ -53,9 +53,9 @@ Du haust einen der Pickel in das Eis.</DefaultText>
     </Entry>
     <Entry>
       <ID>13</ID>
-      <DefaultText>Der Drache dreht wilde Krise durch die Luft. Kalte, abgestandene Luft, die in deinem Gesicht brennt, trägt ihn gen Himmel. Er kracht in die Eiswand über der Siedlung, bevor ihn die unsichtbare Kraft nach oben zieht. Seine wild ausschlagenden Krallen kratzen am Raureif.
+      <DefaultText>Die Drachin dreht wilde Krise durch die Luft. Kalte, abgestandene Luft, die in deinem Gesicht brennt, trägt sie gen Himmel. Sie kracht in die Eiswand über der Siedlung, bevor sie die unsichtbare Kraft nach oben zieht. Ihre wild ausschlagenden Krallen kratzen am Raureif.
 
-Er verschwindet über der Kante des Vorsprungs.</DefaultText>
+Sie verschwindet über der Kante des Vorsprungs.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_02_cv_dracolich.stringtable
+++ b/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_02_cv_dracolich.stringtable
@@ -8,7 +8,7 @@
       <ID>1</ID>
       <DefaultText>&lt;ispeech&gt;Du bist mir in den Abgrund gefolgt? Hast du so wenig übrig für die wenigen Jahre Leben, die deine zerbrechliche Gestalt dir schenkt?&lt;/ispeech&gt;
 
-Der Drache knurrt durch Zähne wie Schwerter, aber die Bedeutung der Worte hallt in deinem Kopf wieder.</DefaultText>
+Die Drachin knurrt durch Zähne wie Schwerter, aber die Bedeutung der Worte hallt in deinem Kopf wieder.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_02_cv_dracolich_phylactery.stringtable
+++ b/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_02_cv_dracolich_phylactery.stringtable
@@ -61,7 +61,7 @@
     </Entry>
     <Entry>
       <ID>13</ID>
-      <DefaultText>„Ich jage einen Gott. Glaubst du, da lasse ich zu, dass mir ein &lt;i&gt;Drache&lt;/i&gt; im Weg steht?“</DefaultText>
+      <DefaultText>„Ich jage einen Gott. Glaubst du, da lasse ich zu, dass mir eine &lt;i&gt;Drachin&lt;/i&gt; im Weg steht?“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -98,7 +98,7 @@ Sie bäumt sich auf und brüllt.</DefaultText>
     </Entry>
     <Entry>
       <ID>20</ID>
-      <DefaultText>Der Drache atmet langsam durch die Nasenlöcher aus und beruhigt sich dabei. Er hebt den Kopf, als ob er aus dem Jenseits blicken könnte.</DefaultText>
+      <DefaultText>Die Drachin atmet langsam durch die Nasenlöcher aus und beruhigt sich dabei. Sie hebt den Kopf, als ob er aus dem Jenseits blicken könnte.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -189,7 +189,7 @@ Das Wesen schlägt seine Flügel. Die spröden Knochen und das trockene Fleisch 
     </Entry>
     <Entry>
       <ID>38</ID>
-      <DefaultText>Sie winkt mit einer Kralle in Richtung eines Gegenstandes, der über dem Sockel zwischen dir und dem Drachen schwebt. Er strahlt spürbare Energie aus.</DefaultText>
+      <DefaultText>Sie winkt mit einer Kralle in Richtung eines Gegenstandes, der über dem Sockel zwischen dir und der Drachin schwebt. Er strahlt spürbare Energie aus.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -304,7 +304,7 @@ Das Wesen schlägt seine Flügel. Die spröden Knochen und das trockene Fleisch 
     </Entry>
     <Entry>
       <ID>62</ID>
-      <DefaultText>Der Drache blickt kurz zu Ydwin und dann wieder zurück zu dir. Violettes Licht flackert in seinen Nüstern.</DefaultText>
+      <DefaultText>Die Drachin blickt kurz zu Ydwin und dann wieder zurück zu dir. Violettes Licht flackert in ihren Nüstern.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -409,7 +409,7 @@ Das Wesen schlägt seine Flügel. Die spröden Knochen und das trockene Fleisch 
     </Entry>
     <Entry>
       <ID>83</ID>
-      <DefaultText>Stille hängt in der Luft, während der Drache über deinen Vorschlag nachdenkt.</DefaultText>
+      <DefaultText>Stille hängt in der Luft, während die Drachin über deinen Vorschlag nachdenkt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -508,7 +508,7 @@ Die Bestie verstummt. Anscheinend denkt sie über deine Worte nach.</DefaultText
       <ID>103</ID>
       <DefaultText>&lt;ispeech&gt;Wie… uninspiriert. Und enttäuschend naiv. Die Gestandenen glauben, was sie wollen, nicht was wahr ist.&lt;/ispeech&gt;
 
-Der Drache schüttelt grob den enormen Kopf.</DefaultText>
+Die Drachin schüttelt grob den enormen Kopf.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -543,7 +543,7 @@ Der Drache schüttelt grob den enormen Kopf.</DefaultText>
     </Entry>
     <Entry>
       <ID>111</ID>
-      <DefaultText>Stille hängt in der Luft, während der Drache über deinen Vorschlag nachdenkt.</DefaultText>
+      <DefaultText>Stille hängt in der Luft, während die Drachin über deinen Vorschlag nachdenkt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -753,7 +753,7 @@ Die Klauen ihrer Hinterläufe graben Furchen in den mit Raureif überzogenen Bod
       <ID>156</ID>
       <DefaultText>&lt;ispeech&gt;Jahrhunderte …&lt;/ispeech&gt;
 
-Der Drache lässt sich auf alle Viere fallen, den Kopf leicht gebeugt.</DefaultText>
+Die Drachin lässt sich auf alle Viere fallen, den Kopf leicht gebeugt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -938,7 +938,7 @@ Du bist dir nicht sicher, ob sie belustigt ist oder nicht.</DefaultText>
       <ID>192</ID>
       <DefaultText>&lt;ispeech&gt;Trotzdem … Wenn ich gegen ihn vorgehen will, muss es jetzt sein, wo ich am Gipfel meiner Macht stehe.&lt;/ispeech&gt;
 
-Der Drache hebt den Kopf und streckt sich.</DefaultText>
+Die Drachin hebt den Kopf und streckt sich.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -995,7 +995,7 @@ Ihr Kopf neigt sich und ihre Augen verblassen ein wenig, während sie nachdenkt.
     </Entry>
     <Entry>
       <ID>203</ID>
-      <DefaultText>„Die Tatsache, dass Rymrgand bisher weder den Drachen besiegen noch das Phylakterium vernichten konnte, lässt vermuten, dass es die Macht des Gottes aufnehmen könnte.“</DefaultText>
+      <DefaultText>„Die Tatsache, dass Rymrgand bisher weder die Drachin besiegen noch das Phylakterium vernichten konnte, lässt vermuten, dass es die Macht des Gottes aufnehmen könnte.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1035,7 +1035,7 @@ Ihr Kopf neigt sich und ihre Augen verblassen ein wenig, während sie nachdenkt.
     </Entry>
     <Entry>
       <ID>212</ID>
-      <DefaultText>Ein tiefes, langes Knurren ertönt von dem Drachen.</DefaultText>
+      <DefaultText>Ein tiefes, langes Knurren ertönt von der Drachin.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1122,7 +1122,7 @@ Ihr Kopf neigt sich und ihre Augen verblassen ein wenig, während sie nachdenkt.
       <ID>229</ID>
       <DefaultText>&lt;ispeech&gt;Dann hat dein Dasein keinen Zweck!&lt;/ispeech&gt;
 
-Der Drache brüllt erneut.</DefaultText>
+Die Drachin brüllt erneut.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1293,7 +1293,7 @@ Maia wischt sich ihre Handflächen und tritt einen Schritt zurück, um das Schau
     </Entry>
     <Entry>
       <ID>267</ID>
-      <DefaultText>„Kapitän, darüber hättest du auch zuerst mit mir sprechen können. Ich bin nicht abgeneigt, die Möglichkeiten zu erkunden.“ Tekēhu schielt den Drachen an.</DefaultText>
+      <DefaultText>„Kapitän, darüber hättest du auch zuerst mit mir sprechen können. Ich bin nicht abgeneigt, die Möglichkeiten zu erkunden.“ Tekēhu schielt die Drachin an.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1312,7 +1312,7 @@ Xoti stemmt die Hände in die Hüften und pustet eine lose Haarsträhne aus ihre
     </Entry>
     <Entry>
       <ID>270</ID>
-      <DefaultText>Stille hängt in der Luft, während der Drache über deinen Vorschlag nachdenkt.</DefaultText>
+      <DefaultText>Stille hängt in der Luft, während die Drachin über deinen Vorschlag nachdenkt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_02_cv_engwith_shackled_soul.stringtable
+++ b/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_02_cv_engwith_shackled_soul.stringtable
@@ -714,7 +714,7 @@ Sie sieht in Richtung der Mitte des Reiches und der Struktur, die dort thront.</
     </Entry>
     <Entry>
       <ID>146</ID>
-      <DefaultText>„Hilf mir, einen uralten Drachen zu töten.“</DefaultText>
+      <DefaultText>„Hilf mir, eine uralte Drachin zu töten.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_02_cv_engwith_trial_02.stringtable
+++ b/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_02_cv_engwith_trial_02.stringtable
@@ -449,7 +449,7 @@ Ihr verhüllter Kopf raschelt leise, während sie ihn schüttelt.</DefaultText>
     <Entry>
       <ID>110</ID>
       <DefaultText>„Ich bin der Herold von Berath. Ich trage ihr Zeichen.“</DefaultText>
-      <FemaleText />
+      <FemaleText>„Ich bin Beraths Herold. Ich trage ihr Zeichen.“</FemaleText>
     </Entry>
     <Entry>
       <ID>111</ID>

--- a/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_02_cv_frozen_guardian.stringtable
+++ b/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_02_cv_frozen_guardian.stringtable
@@ -120,7 +120,7 @@ Seufzend schüttelt sie den Kopf.</DefaultText>
     </Entry>
     <Entry>
       <ID>24</ID>
-      <DefaultText>„Tu, was du willst, solange du den Drachen tötest.“</DefaultText>
+      <DefaultText>„Tu, was du willst, solange du die Drachin tötest.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -327,7 +327,7 @@ Ihr Kopf neigt sich leicht zur Seite, während sie dein Gesicht begutachtet.</De
     </Entry>
     <Entry>
       <ID>74</ID>
-      <DefaultText>„Ich bin da keine Ausnahme. Ich habe meine Energie dafür verbraucht, nach Rymrgand zu rufen. Was von mir übriggeblieben ist, steht hier Wache. Gegen den Drachen.“</DefaultText>
+      <DefaultText>„Ich bin da keine Ausnahme. Ich habe meine Energie dafür verbraucht, nach Rymrgand zu rufen. Was von mir übriggeblieben ist, steht hier Wache. Gegen die Drachin.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -353,7 +353,7 @@ Ihr Kopf neigt sich leicht zur Seite, während sie dein Gesicht begutachtet.</De
     <Entry>
       <ID>79</ID>
       <DefaultText>„Deine Anwesenheit impliziert, dass Rymrgand einen neuen Beschützer auserwählt hat, um der Drachin die Klinge zuzuführen.“</DefaultText>
-      <FemaleText>„Deine Anwesenheit impliziert, dass Rymrgand eine neue Wächterin auserwählt hat, um dem Drachen die Klinge zuzuführen.“</FemaleText>
+      <FemaleText>„Deine Anwesenheit impliziert, dass Rymrgand eine neue Wächterin auserwählt hat, um der Drachin die Klinge zuzuführen.“</FemaleText>
     </Entry>
     <Entry>
       <ID>80</ID>
@@ -382,7 +382,7 @@ Ihr Kopf neigt sich leicht zur Seite, während sie dein Gesicht begutachtet.</De
     </Entry>
     <Entry>
       <ID>85</ID>
-      <DefaultText>„Sogar das hat sich als unwirksam herausgestellt. Das letzte, was ich gesehen habe, bevor der Frost mir das Augenlicht nahm, war der Drache, der sich seinen Weg durch uns in den Schlund malmte.“</DefaultText>
+      <DefaultText>„Sogar das hat sich als unwirksam herausgestellt. Das letzte, was ich gesehen habe, bevor der Frost mir das Augenlicht nahm, war die Drachin, die sich ihren Weg durch uns in den Schlund malmte.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -526,7 +526,7 @@ Ein unsicheres Stirnrunzeln dominiert ihre weißen Gesichtszüge.</DefaultText>
     </Entry>
     <Entry>
       <ID>114</ID>
-      <DefaultText>„Für uns besteht kein Unterschied. Seelen, die hierhergebracht werden, zerbrechen. Zerfallen zu Staub. Seine Kinder sammeln die Überreste auf und bringen sie in das Nichts.“ Sie gestikuliert in Richtung der unbeweglichen, ungleichen Form, die der Drache hinterlassen hat.</DefaultText>
+      <DefaultText>„Für uns besteht kein Unterschied. Seelen, die hierhergebracht werden, zerbrechen. Zerfallen zu Staub. Seine Kinder sammeln die Überreste auf und bringen sie in das Nichts.“ Sie gestikuliert in Richtung der unbeweglichen, ungleichen Form, die die Drachin hinterlassen hat.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -724,7 +724,7 @@ Sie runzelt die Stirn in dem Versuch, die Worte zu finden, die eine adäquate Er
     </Entry>
     <Entry>
       <ID>158</ID>
-      <DefaultText>„Dann lass mich deine Fragen hören, wenn sie zum Ende des Drachen führen.“</DefaultText>
+      <DefaultText>„Dann lass mich deine Fragen hören, wenn sie zum Ende der Drachin führen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1060,7 +1060,7 @@ Er winkt verächtlich zu Rynhaedr hin.</DefaultText>
     </Entry>
     <Entry>
       <ID>223</ID>
-      <DefaultText>„Lasst uns endlich diesen Drachen töten oder dieses Portal schließen oder was auch immer wir deiner Meinung nach tun sollen.“</DefaultText>
+      <DefaultText>„Lasst uns endlich diese Drachin töten oder dieses Portal schließen oder was auch immer wir deiner Meinung nach tun sollen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1559,7 +1559,7 @@ Sie grinst den König abschätzig an.</DefaultText>
     </Entry>
     <Entry>
       <ID>321</ID>
-      <DefaultText>„Unzweifelhaft ist die Hilfe eines Königs unschätzbar, um den Drachen zu bezwingen.“</DefaultText>
+      <DefaultText>„Unzweifelhaft ist die Hilfe eines Königs unschätzbar, um die Drachin zu bezwingen.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -1672,7 +1672,7 @@ Sie seufzt.</DefaultText>
     </Entry>
     <Entry>
       <ID>342</ID>
-      <DefaultText>Du erspähst den Drachen auf einem breiten Stück Eis direkt unter dir. Du kannst hinabsteigen, siehst aber keinen einfachen Weg zurück.</DefaultText>
+      <DefaultText>Du erspähst die Drachin auf einem breiten Stück Eis direkt unter dir. Du kannst hinabsteigen, siehst aber keinen einfachen Weg zurück.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_02_si_dracolich_ending.stringtable
+++ b/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_02_si_dracolich_ending.stringtable
@@ -6,7 +6,7 @@
   <Entries>
     <Entry>
       <ID>1</ID>
-      <DefaultText>Der Drache stemmt sich vor auf seine Knie und kratzt mit seinen Vorderklauen an seinem hageren Brustkorb herum, während sein fauliges Fleisch von den arkanen Energien im Inneren ausgebeult und verzerrt wird.</DefaultText>
+      <DefaultText>Die Drachin stemmt sich vor auf seine Knie und kratzt mit ihren Vorderklauen an ihrem hageren Brustkorb herum, während ihr fauliges Fleisch von den arkanen Energien im Inneren ausgebeult und verzerrt wird.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -16,7 +16,7 @@
     </Entry>
     <Entry>
       <ID>3</ID>
-      <DefaultText>Du weichst den schwingenden Krallen des Drachen aus und stößt mit deiner Hand tief in seine ausgetrocknete Brust. Mit deinen Händen greifst du nach dem Relikt, dessen Wärme nun durch deine Finger pulsiert. Dann reißt du es aus der Brust des Drachen.</DefaultText>
+      <DefaultText>Du weichst den schwingenden Krallen der Drachin aus und stößt mit deiner Hand tief in ihre ausgetrocknete Brust. Mit deinen Händen greifst du nach dem Relikt, dessen Wärme nun durch deine Finger pulsiert. Dann reißt du es aus der Brust der Drachin.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -31,7 +31,7 @@
     </Entry>
     <Entry>
       <ID>6</ID>
-      <DefaultText>[Specified 0] weicht den wild herumwirbelnden Klauen des Drachen aus und stößt dann einen Arm bis zum Ellbogen in den Brustkorb der Bestie. Dein Begleiter springt davon, mit Eingeweiden verschmierte Finger fest um das leuchtende Relikt geschlossen.</DefaultText>
+      <DefaultText>[Specified 0] weicht den wild herumwirbelnden Klauen der Drachin aus und stößt dann einen Arm bis zum Ellbogen in den Brustkorb der Bestie. Dein Begleiter springt davon, mit Eingeweiden verschmierte Finger fest um das leuchtende Relikt geschlossen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -41,12 +41,12 @@
     </Entry>
     <Entry>
       <ID>8</ID>
-      <DefaultText>Essenz explodiert im Innern der Brust des Drachen, wodurch das Relikt herausgeschleudert wird. Es schlittert sich drehend über den Boden, bis es vor deinen Füßen zum Stillstand kommt.</DefaultText>
+      <DefaultText>Essenz explodiert im Innern der Brust der Drachin, wodurch das Relikt herausgeschleudert wird. Es schlittert sich drehend über den Boden, bis es vor deinen Füßen zum Stillstand kommt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>10</ID>
-      <DefaultText>Du stößt deine Hand tief in die ausgetrocknete Brust des Drachen, trotz der Klauen, die deinen Rücken zerkratzen. Mit deinen Händen greifst du nach dem Relikt, dessen Wärme nun durch deine Finger pulsiert. Dann reißt du es aus der Brust des Drachen.</DefaultText>
+      <DefaultText>Du stößt deine Hand tief in die ausgetrocknete Brust der Drachin, trotz der Klauen, die deinen Rücken zerkratzen. Mit deinen Händen greifst du nach dem Relikt, dessen Wärme nun durch deine Finger pulsiert. Dann reißt du es aus der Brust der Drachin.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -56,7 +56,7 @@
     </Entry>
     <Entry>
       <ID>12</ID>
-      <DefaultText>Der Hals des Drachen wendet sich. Er dreht seinen Kopf, um dir mit seinem leuchtenden Auge einen unheilvollen Blick zuzuwerfen.</DefaultText>
+      <DefaultText>Der Hals der Drachin wendet sich. Sie dreht ihren Kopf, um dir mit ihrem leuchtenden Auge einen unheilvollen Blick zuzuwerfen.</DefaultText>
       <FemaleText />
     </Entry>
   </Entries>

--- a/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_02_si_whitevoid_rymrgand.stringtable
+++ b/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_02_si_whitevoid_rymrgand.stringtable
@@ -16,7 +16,7 @@
     </Entry>
     <Entry>
       <ID>5</ID>
-      <DefaultText>„Ich habe den Drachen vernichtet, wie du es verlangt hast. Meinen Teil der Abmachung habe ich gehalten, jetzt bist du am Zug.“</DefaultText>
+      <DefaultText>„Ich habe die Drachin vernichtet, wie du es verlangt hast. Meinen Teil der Abmachung habe ich gehalten, jetzt bist du am Zug.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -253,14 +253,14 @@ Die Bestie klopft mit dem Griff ihrer Axt zweimal auf den Boden und nickt.</Fema
     </Entry>
     <Entry>
       <ID>66</ID>
-      <DefaultText>„Der Drache ist fort, und seine Verderbnis kann das Relikt jetzt nicht mehr beschmutzen. Gut.“</DefaultText>
+      <DefaultText>„Die Drachin ist fort, und ihre Verderbnis kann das Relikt jetzt nicht mehr beschmutzen. Gut.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>73</ID>
       <DefaultText>„Ich habe von dir verlangt, Neriscyrlas zu zerstören, und du hast sie ins Herz meines Reiches getrieben.“
 
-Die Bestie hebt das Phylakterion hoch, das vom Drachen zurückgelassen wurde.</DefaultText>
+Die Bestie hebt das Phylakterion hoch, das von der Drachin zurückgelassen wurde.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -270,7 +270,7 @@ Die Bestie hebt das Phylakterion hoch, das vom Drachen zurückgelassen wurde.</D
     </Entry>
     <Entry>
       <ID>75</ID>
-      <DefaultText>„Das Relikt, das du ihr entrissen hast … Gib es mir, und ich werde es von der Verderbnis des Drachen befreien.“</DefaultText>
+      <DefaultText>„Das Relikt, das du ihr entrissen hast … Gib es mir, und ich werde es von der Verderbnis der Drachin befreien.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -342,7 +342,7 @@ Er legt das Relikt in deine wartenden Hände zurück.</DefaultText>
     </Entry>
     <Entry>
       <ID>89</ID>
-      <DefaultText>„Ich habe getan, was du von mir verlangt hast – ich habe dir diesen Drachen geschickt. Du schuldest mir etwas.“</DefaultText>
+      <DefaultText>„Ich habe getan, was du von mir verlangt hast – ich habe dir diese Drachin geschickt. Du schuldest mir etwas.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -352,7 +352,7 @@ Er legt das Relikt in deine wartenden Hände zurück.</DefaultText>
     </Entry>
     <Entry>
       <ID>91</ID>
-      <DefaultText>„Ich habe dir gesagt, du sollst den Drachen Neriscyrlas töten, und das hast du nicht getan.“</DefaultText>
+      <DefaultText>„Ich habe dir gesagt, du sollst die Drachin Neriscyrlas töten, und das hast du nicht getan.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -859,7 +859,7 @@ Sie strafft die Schultern.</DefaultText>
     </Entry>
     <Entry>
       <ID>220</ID>
-      <DefaultText>„Die Kraft, die die Höhle des Drachen zusammenhielt, ist jetzt fort. Verloren im Nichts, wie alle Dinge.“</DefaultText>
+      <DefaultText>„Die Kraft, die die Höhle der Drachin zusammenhielt, ist jetzt fort. Verloren im Nichts, wie alle Dinge.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_endgameslides.stringtable
+++ b/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_endgameslides.stringtable
@@ -11,7 +11,7 @@
     </Entry>
     <Entry>
       <ID>6</ID>
-      <DefaultText>Der Drache Neriscyrlas wandert nicht länger zwischen Eora und dem Weißen Nichts hin und her. Durch das langsame Auseinanderbrechen der Toten Eisscholle wird der Tempel freigegeben, der so lange in ihrem Eis eingeschlossen war.</DefaultText>
+      <DefaultText>Die Drachin Neriscyrlas wandert nicht länger zwischen Eora und dem Weißen Nichts hin und her. Durch das langsame Auseinanderbrechen der Toten Eisscholle wird der Tempel freigegeben, der so lange in ihrem Eis eingeschlossen war.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_poi_bs_bridge_ablaze_arrival.stringtable
+++ b/lax2_exported/localized/de_patch/text/conversations/lax02_01_iceberg_dungeon/lax02_poi_bs_bridge_ablaze_arrival.stringtable
@@ -56,7 +56,7 @@
     </Entry>
     <Entry>
       <ID>16</ID>
-      <DefaultText>„Ich glaube, es kann nicht viel seltsamer werden als ein untoter Drache. Aber warten wir’s ab.“</DefaultText>
+      <DefaultText>„Ich glaube, es kann nicht viel seltsamer werden als eine untote Drachin. Aber warten wir’s ab.“</DefaultText>
       <FemaleText />
     </Entry>
   </Entries>

--- a/lax2_exported/localized/de_patch/text/game/items.stringtable
+++ b/lax2_exported/localized/de_patch/text/game/items.stringtable
@@ -479,7 +479,7 @@ Das gefütterte Fell stinkt nach Verfall und die Raureif-Scherben, die es bedeck
     </Entry>
     <Entry>
       <ID>5398</ID>
-      <DefaultText>Der weibliche Drache Neriscyrlas klammerte sich mit verbissener Sturheit an das Leben und wehrte sich gegen den Verfall, der Fleisch, Knochen und Seele langsam auffraß. Offensichtlich konnte sich nicht einmal der &lt;xg&gt;Tod&lt;/xg&gt; gegen einen solch entschlossenen Willen durchsetzen. Der Schädel des Drachen ist hohl und leblos wie ein Stück Treibholz, aber hin und wieder dringt eine leise flüsternde Stimme aus der Tiefe empor, die darum fleht, in den Kampf ziehen zu dürfen.</DefaultText>
+      <DefaultText>Der weibliche Drache Neriscyrlas klammerte sich mit verbissener Sturheit an das Leben und wehrte sich gegen den Verfall, der Fleisch, Knochen und Seele langsam auffraß. Offensichtlich konnte sich nicht einmal der &lt;xg&gt;Tod&lt;/xg&gt; gegen einen solch entschlossenen Willen durchsetzen. Der Schädel der Drachin ist hohl und leblos wie ein Stück Treibholz, aber hin und wieder dringt eine leise flüsternde Stimme aus der Tiefe empor, die darum fleht, in den Kampf ziehen zu dürfen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax2_exported/localized/de_patch/text/quests/lax02_01_iceberg_dungeon/lax02_qst_critical_path_quest_01.stringtable
+++ b/lax2_exported/localized/de_patch/text/quests/lax02_01_iceberg_dungeon/lax02_qst_critical_path_quest_01.stringtable
@@ -63,7 +63,7 @@ Wenn ich es rausfinden will, muss ich zur &lt;b&gt;Botenwacht&lt;/b&gt; reisen, 
     </Entry>
     <Entry>
       <ID>10005</ID>
-      <DefaultText>&lt;b&gt;Vatnir&lt;/b&gt; hat es nie nach draußen geschafft. Nachdem ich den Vorboten der Boten – einen verfaulenden Drachen – erschlagen habe, sollte ich den Gottähnlichen finden und ihn fragen, was los ist.</DefaultText>
+      <DefaultText>&lt;b&gt;Vatnir&lt;/b&gt; hat es nie nach draußen geschafft. Nachdem ich den Vorboten der Boten – eine verfaulende Drachin – erschlagen habe, sollte ich den Gottähnlichen finden und ihn fragen, was los ist.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax2_exported/localized/de_patch/text/quests/lax02_01_iceberg_dungeon/lax02_qst_critical_path_quest_02.stringtable
+++ b/lax2_exported/localized/de_patch/text/quests/lax02_01_iceberg_dungeon/lax02_qst_critical_path_quest_02.stringtable
@@ -62,7 +62,7 @@ Wenn ich irgendwelche Hoffnung habe, den Vytmádh zu verschließen, dann muss ic
     </Entry>
     <Entry>
       <ID>20000</ID>
-      <DefaultText>Als ich aus dem Rückzug der Boten auftauchte, kehrte der von mir getötete Drache zum Leben zurück. Er schien von einer unnatürlichen Kraft wieder an die &lt;b&gt;Spitze des Eisbergs&lt;/b&gt; gebracht worden zu sein. Vielleicht weiß die Kreatur – oder was immer ihn aus der Botenwacht zog – mehr über den &lt;b&gt;Vytmádh&lt;/b&gt;.</DefaultText>
+      <DefaultText>Als ich aus dem Rückzug der Boten auftauchte, kehrte die von mir getötete Drachin zum Leben zurück. Er schien von einer unnatürlichen Kraft wieder an die &lt;b&gt;Spitze des Eisbergs&lt;/b&gt; gebracht worden zu sein. Vielleicht weiß die Kreatur – oder was immer ihn aus der Botenwacht zog – mehr über den &lt;b&gt;Vytmádh&lt;/b&gt;.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -77,7 +77,7 @@ Wenn ich irgendwelche Hoffnung habe, den Vytmádh zu verschließen, dann muss ic
     </Entry>
     <Entry>
       <ID>20003</ID>
-      <DefaultText>Ich fand den &lt;b&gt;Drachen&lt;/b&gt;, nur um zu sehen wie er gegen seinen Willen in die weiße Kälte des &lt;b&gt;Vytmádh&lt;/b&gt; gezogen wurde.</DefaultText>
+      <DefaultText>Ich fand die &lt;b&gt;Drachin&lt;/b&gt;, nur um zu sehen, wie sie gegen ihren Willen in die weiße Kälte des &lt;b&gt;Vytmádh&lt;/b&gt; gezogen wurde.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -92,7 +92,7 @@ Wenn ich irgendwelche Hoffnung habe, den Vytmádh zu verschließen, dann muss ic
     </Entry>
     <Entry>
       <ID>30000</ID>
-      <DefaultText>Ich schritt durch den Vytmádh und betrat das Jenseits. Jetzt muss ich es nach dem &lt;b&gt;Drachen&lt;/b&gt; durchsuchen, der verhindert, dass das &lt;b&gt;Portal&lt;/b&gt; versiegelt wird.</DefaultText>
+      <DefaultText>Ich schritt durch den Vytmádh und betrat das Jenseits. Jetzt muss ich es nach der &lt;b&gt;Drachin&lt;/b&gt; durchsuchen, die verhindert, dass das &lt;b&gt;Portal&lt;/b&gt; versiegelt wird.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax2_exported/localized/de_patch/text/quests/lax02_01_iceberg_dungeon/lax02_qst_critical_path_quest_03.stringtable
+++ b/lax2_exported/localized/de_patch/text/quests/lax02_01_iceberg_dungeon/lax02_qst_critical_path_quest_03.stringtable
@@ -51,7 +51,7 @@
     </Entry>
     <Entry>
       <ID>10002</ID>
-      <DefaultText>Neriscyrlas hat sich in seiner Höhle versteckt, tief im Weißen Nichts. Die Beschützerin Rynhaedr warnte mich davor, ohne Hilfe von den hiesigen Wesen noch tiefer in Rymrgands Reich vorzudringen.
+      <DefaultText>Neriscyrlas hat sich in ihrer Höhle versteckt, tief im Weißen Nichts. Die Beschützerin Rynhaedr warnte mich davor, ohne Hilfe von den hiesigen Wesen noch tiefer in Rymrgands Reich vorzudringen.
 
 Ich könnte diese &lt;b&gt;verfallenden Reiche&lt;/b&gt; nach magischen Hilfen durchsuchen und vielleicht auch die Hilfe von &lt;b&gt;Seelen&lt;/b&gt; heranziehen, die sich in dem blassen Abgrund über Wasser halten.
 

--- a/lax2_exported/localized/de_patch/text/quests/lax02_01_iceberg_dungeon/lax02_qst_critical_path_quest_03_godhmr_plane.stringtable
+++ b/lax2_exported/localized/de_patch/text/quests/lax02_01_iceberg_dungeon/lax02_qst_critical_path_quest_03_godhmr_plane.stringtable
@@ -114,7 +114,7 @@ Die &lt;b&gt;Erinnerungen&lt;/b&gt; an sein unversehrtes Sein &lt;b&gt;wiederher
     </Entry>
     <Entry>
       <ID>30001</ID>
-      <DefaultText>Ich überzeugte &lt;b&gt;Waidwen&lt;/b&gt;, sich zu rehabilitieren, indem er gegen den Drachen Neriscyrlas kämpft.</DefaultText>
+      <DefaultText>Ich überzeugte &lt;b&gt;Waidwen&lt;/b&gt;, sich zu rehabilitieren, indem er gegen die Drachin Neriscyrlas kämpft.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax2_exported/localized/de_patch/text/quests/lax02_01_iceberg_dungeon/lax02_qst_critical_path_quest_03_huana_plane.stringtable
+++ b/lax2_exported/localized/de_patch/text/quests/lax02_01_iceberg_dungeon/lax02_qst_critical_path_quest_03_huana_plane.stringtable
@@ -67,7 +67,7 @@ Wenn ich dem Geist wieder zu seiner &lt;b&gt;Machtposition&lt;/b&gt; verhelfe, k
     </Entry>
     <Entry>
       <ID>30001</ID>
-      <DefaultText>Ich überzeugte &lt;b&gt;König Wingauro o Watūri I&lt;/b&gt;, sich mit seinem Versagen abzufinden. Durch neu gefundenen Mut gestärkt, stimmte er zu, mir beim Kampf gegen den Drachen &lt;b&gt;Neriscyrlas&lt;/b&gt; zu helfen.</DefaultText>
+      <DefaultText>Ich überzeugte &lt;b&gt;König Wingauro o Watūri I&lt;/b&gt;, sich mit seinem Versagen abzufinden. Durch neu gefundenen Mut gestärkt, stimmte er zu, mir beim Kampf gegen die Drachin &lt;b&gt;Neriscyrlas&lt;/b&gt; zu helfen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_01_cv_oracle_beyond.stringtable
+++ b/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_01_cv_oracle_beyond.stringtable
@@ -172,7 +172,7 @@
     <Entry>
       <ID>38</ID>
       <DefaultText>„Ich bin der Herold von Berath.“</DefaultText>
-      <FemaleText />
+      <FemaleText>„Ich bin Beraths Herold.“</FemaleText>
     </Entry>
     <Entry>
       <ID>39</ID>

--- a/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_04_si_wael.stringtable
+++ b/lax3_exported/localized/de_patch/text/conversations/lax03_forgotten_sanctum/lax03_04_si_wael.stringtable
@@ -304,7 +304,7 @@ Die feuchte und warme Luft klebt an deiner Haut.</DefaultText>
     <Entry>
       <ID>73</ID>
       <DefaultText>„Du scheinst zu vergessen, dass ich der Herold von Berath bin. Sie &lt;i&gt;wird&lt;/i&gt; erfahren, was ich hier gefunden habe. Vielleicht möchtest du diese Entscheidung noch einmal überdenken?“</DefaultText>
-      <FemaleText />
+      <FemaleText>„Du scheinst zu vergessen, dass ich Herold von Berath bin. Sie &lt;i&gt;wird&lt;/i&gt; erfahren, was ich hier gefunden habe. Vielleicht möchtest du diese Entscheidung noch einmal überdenken?“</FemaleText>
     </Entry>
     <Entry>
       <ID>74</ID>
@@ -600,7 +600,7 @@ Die Augen der Gottheit funkeln wie die Sterne am Firmament.</FemaleText>
     <Entry>
       <ID>132</ID>
       <DefaultText>„Du scheinst zu vergessen, dass ich der Herold von Berath bin. Sie &lt;i&gt;wird&lt;/i&gt; erfahren, was ich hier gefunden habe. Vielleicht möchtest du diese Entscheidung noch einmal überdenken?“</DefaultText>
-      <FemaleText />
+      <FemaleText>„Du scheinst zu vergessen, dass ich Herold von Berath bin. Sie &lt;i&gt;wird&lt;/i&gt; erfahren, was ich hier gefunden habe. Vielleicht möchtest du diese Entscheidung noch einmal überdenken?“</FemaleText>
     </Entry>
     <Entry>
       <ID>133</ID>


### PR DESCRIPTION
3 "Pakete":
1. neue FemaleTexte, in denen "DER Herold von Berath" soweit möglich durch "Beraths Herold" oder "Herold von Betrath" (ohne Artikel) erstzt wird
2. Neriscyrlas wird jetzt durchgängig als "Drachin" und "sie" bezeichnet
3. in den endgameslides diverse FemaleTexte ergänzt (Wächter-> Wächterin), vor allem bei Pallegina ab ID 246; dabei auch andere Fehler behoben

(zu 2.: In letzter Konsequenz müsste man wohl auch an den Magmadrachen als "Drachin" ran, und auch die Bezüge auf den Himmelsdrachen aus PoE1 sollten weiblich sein...)