### PR TITLE
Diverses

### DIFF
--- a/exported/localized/de_patch/text/conversations/09_port_maje/09_cv_port_maje_banter_bank.stringtable
+++ b/exported/localized/de_patch/text/conversations/09_port_maje/09_cv_port_maje_banter_bank.stringtable
@@ -136,7 +136,7 @@
     </Entry>
     <Entry>
       <ID>28</ID>
-      <DefaultText>„Vielleicht sollten wir sie feuern? Wir legen sowie nicht so bald ab.“</DefaultText>
+      <DefaultText>„Vielleicht sollten wir sie feuern? Wir legen sowieso nicht so bald ab.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/exported/localized/de_patch/text/conversations/09_port_maje/09_cv_rinco.stringtable
+++ b/exported/localized/de_patch/text/conversations/09_port_maje/09_cv_rinco.stringtable
@@ -287,7 +287,7 @@ Er gestikuliert kraftlos mit einem Arm und grimassiert.</DefaultText>
     </Entry>
     <Entry>
       <ID>72</ID>
-      <DefaultText>„Sie nennen sie Mokeha. Ich vermute, sie ist wieder in ihrem Dorf. Zweifellos fühlt sie sich auch noch stolz darauf.
+      <DefaultText>„Sie nennen sie Mokeha. Ich vermute, sie ist wieder in ihrem Dorf. Zweifellos ist sie auch noch stolz auf sich.
 
 Folge der Straße, wo sie nach Norden abbiegt, dann nach Westen. Du kannst es nicht verpassen. Ein Haufen Stöcke und Stroh.“</DefaultText>
       <FemaleText />

--- a/exported/localized/de_patch/text/conversations/companions/companion_cv_xoti_intro_pm.stringtable
+++ b/exported/localized/de_patch/text/conversations/companions/companion_cv_xoti_intro_pm.stringtable
@@ -190,7 +190,7 @@ Eine kleinere, dunkelhäutigere Frau beobachtet das Ritual mit verschränkten Ar
     </Entry>
     <Entry>
       <ID>40</ID>
-      <DefaultText>„Du bist in den Tiefen des Meeres gewandelt, doch du bist nicht ertrunken. Und in deiner Hand hast du den Schlüssel zu Eoras Ende.“
+      <DefaultText>„Du bist in den Tiefen des Meeres gewandelt, doch du bist nicht ertrunken. Und in deiner Hand hattest du den Schlüssel zu Eoras Ende.“
 
 Ihr Gesicht leuchtet grimmig auf.</DefaultText>
       <FemaleText />
@@ -705,7 +705,7 @@ Die Frau ringt ihre Hände, bevor sie ihre zitternden, wachsverschmierten Finger
     <Entry>
       <ID>155</ID>
       <DefaultText>„Ich bin ein Wächter.“</DefaultText>
-      <FemaleText />
+      <FemaleText>„Ich bin eine Wächterin.“</FemaleText>
     </Entry>
     <Entry>
       <ID>156</ID>

--- a/exported/localized/de_patch/text/conversations/companions/companion_cv_xoti_main.stringtable
+++ b/exported/localized/de_patch/text/conversations/companions/companion_cv_xoti_main.stringtable
@@ -1809,7 +1809,7 @@ Sie verschränkt die Arme über ihrer Brust und runzelt die Stirn, bis sie auf e
     </Entry>
     <Entry>
       <ID>352</ID>
-      <DefaultText>„Du bist in den Tiefen des Meeres gewandelt, doch du bist nicht ertrunken. Und in deiner Hand hast du den Schlüssel zu Eoras Ende.“
+      <DefaultText>„Du bist in den Tiefen des Meeres gewandelt, doch du bist nicht ertrunken. Und in deiner Hand hattest du den Schlüssel zu Eoras Ende.“
 
 Ihr Gesicht leuchtet grimmig auf.</DefaultText>
       <FemaleText />

--- a/exported/localized/de_patch/text/conversations/re_scripted_interactions/re_si_supply_wagon_trap.stringtable
+++ b/exported/localized/de_patch/text/conversations/re_scripted_interactions/re_si_supply_wagon_trap.stringtable
@@ -145,7 +145,7 @@ Aufmerksam beobachtet Serafen die Umgebung der Straße. Seine Ohren zucken.</Def
     </Entry>
     <Entry>
       <ID>150</ID>
-      <DefaultText>Zwei Bussarde sitzen auf der Seite des Wagens, und ein weiter hüpft auf dem Boden herum. Aus seinem Maul hängt ein Stück blutiges Fleisch.
+      <DefaultText>Zwei Bussarde sitzen auf der Seite des Wagens, und ein weiter hüpft auf dem Boden herum. Aus seinem Schnabel hängt ein Stück blutiges Fleisch.
 
 Überall auf dem Wagen liegen Leichen in unnatürlichen Haltungen. In den Wagenbrettern stecken Pfeile.</DefaultText>
       <FemaleText />
@@ -191,12 +191,12 @@ Eine Gruppe Briganten hat den Wagen umstellt. Sie sind gut bewaffnet und tragen 
     </Entry>
     <Entry>
       <ID>159</ID>
-      <DefaultText>Als du dich dem Wagen näherst, siehst du eine Gruppe von readceranischer Pilger in Kleidung aus grob gesponnenen Leinen- und Baumwollstoffen. Ein einzelnes Zugpferd stampft ungeduldig mit dem Huf auf den Boden. Zwei der Pilger diskutieren über das rechte Vorderrad, das hoffnungslos im Schlamm festzustecken scheint.</DefaultText>
+      <DefaultText>Als du dich dem Wagen näherst, siehst du eine Gruppe readceranischer Pilger in Kleidung aus grob gesponnenen Leinen- und Baumwollstoffen. Ein einzelnes Zugpferd stampft ungeduldig mit dem Huf auf den Boden. Zwei der Pilger diskutieren über das rechte Vorderrad, das hoffnungslos im Schlamm festzustecken scheint.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
       <ID>160</ID>
-      <DefaultText>Als du dich dem Wagen näherst, siehst du eine Gruppe von readceranischer Pilger in Kleidung aus grob gesponnenen Leinen- und Baumwollstoffen. Ein einzelnes Zugpferd stampft ungeduldig mit dem Huf auf den Boden. Zwei der Pilger diskutieren über das rechte Vorderrad, das hoffnungslos im Schlamm festzustecken scheint.</DefaultText>
+      <DefaultText>Als du dich dem Wagen näherst, siehst du eine Gruppe readceranischer Pilger in Kleidung aus grob gesponnenen Leinen- und Baumwollstoffen. Ein einzelnes Zugpferd stampft ungeduldig mit dem Huf auf den Boden. Zwei der Pilger diskutieren über das rechte Vorderrad, das hoffnungslos im Schlamm festzustecken scheint.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -371,7 +371,7 @@ Die Briganten treten zurück, ohne die Augen von dir zu lassen. Oder die Hände 
     </Entry>
     <Entry>
       <ID>212</ID>
-      <DefaultText>„Du willst [Player Name] ausrauben, einen Verbündeten der Príncipi? Du weißt doch sicher, wo zu das führt und wie das endet.“</DefaultText>
+      <DefaultText>„Du willst [Player Name] ausrauben, einen Verbündeten der Príncipi? Du weißt doch sicher, wozu das führt und wie das endet.“</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -526,7 +526,7 @@ Die Pilger sehen sich um und gleichen ihre Erinnerungen aus dem Traum mit der Ge
     </Entry>
     <Entry>
       <ID>245</ID>
-      <DefaultText>Mit nach unten gerichteten Augen überreichen die Pilger ihre Habseligkeiten und bewegen sich niedergeschlagen hin zu einem kleinen Kreis neben dem Wagen als ihr weggeht.</DefaultText>
+      <DefaultText>Mit nach unten gerichteten Augen überreichen die Pilger ihre Habseligkeiten und bewegen sich niedergeschlagen hin zu einem kleinen Kreis neben dem Wagen, als ihr weggeht.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/exported/localized/de_patch/text/game/abilities.stringtable
+++ b/exported/localized/de_patch/text/game/abilities.stringtable
@@ -2811,7 +2811,7 @@
     </Entry>
     <Entry>
       <ID>865</ID>
-      <DefaultText>Der Barbar ist in der Lage mit erbarmungsloser Hingabe anzugreifen, wodurch er die Inspiration Flink erhält sowie immun gegen Angriffsbindungen wird.</DefaultText>
+      <DefaultText>Der Barbar ist in der Lage, mit erbarmungsloser Hingabe anzugreifen, wodurch er die Inspiration Flink erhält sowie immun gegen Angriffsbindungen wird.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -2921,7 +2921,7 @@
     </Entry>
     <Entry>
       <ID>896</ID>
-      <DefaultText>Ein mächtiger Angriff, der das Ziel eine über beachtliche &lt;xg&gt;Distanz&lt;/xg&gt; zurückwirft und es mit dem Effekt Niedergestreckt belegt.</DefaultText>
+      <DefaultText>Ein mächtiger Angriff, der das Ziel eine beachtliche &lt;xg&gt;Distanz&lt;/xg&gt; zurückwirft und es mit dem Effekt Niedergestreckt belegt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/exported/localized/de_patch/text/game/gui.stringtable
+++ b/exported/localized/de_patch/text/game/gui.stringtable
@@ -9969,7 +9969,7 @@ Du kannst deine Wahl später nicht mehr ändern.</DefaultText>
     </Entry>
     <Entry>
       <ID>2162</ID>
-      <DefaultText>Der Charakter sucht aktiv nach Feinden in der Näher, die er angreifen kann – unabhängig davon, ob er selbst direkt angegriffen wird oder nicht.</DefaultText>
+      <DefaultText>Der Charakter sucht aktiv nach Feinden in der Nähe, die er angreifen kann – unabhängig davon, ob er selbst direkt angegriffen wird oder nicht.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/exported/localized/de_patch/text/game/items.stringtable
+++ b/exported/localized/de_patch/text/game/items.stringtable
@@ -16463,7 +16463,7 @@ Ngati führe uns in dieser schwierigen Zeit.
     </Entry>
     <Entry>
       <ID>5234</ID>
-      <DefaultText>In diese fragile Tafel wurden vor Tausenden von Jahren mühselig Engwithan–Runen eingeritzt.
+      <DefaultText>In diese fragile Tafel wurden vor Tausenden von Jahren mühselig engwithanische Runen eingeritzt.
 
 „Die Festival–Laternen leuchten mit einem warmen, gelben Licht und wippen durch die leichte Brise vom Meer auf und ab. Die jungen Leute tanzen, stampfen mit den Füßen und lächeln breit, eine fieberhafte Freude spiegelt sich in ihren Augen wider. Die Alten trinken und erzählen Geschichten aus lang vergangenen Zeiten, ihr Lachen ist laut genug, um den Adra unter unseren Füßen zu erschüttern. Und die Kinder, für die wir das tun, unsere Zukunft – sie stehlen Süßigkeiten von den Banketttischen, sie raufen und necken und kämpfen wie Kinder das tun sollten und meine Seele schwillt vor Stolz an.
 

--- a/exported/localized/de_patch/text/game/items.stringtable
+++ b/exported/localized/de_patch/text/game/items.stringtable
@@ -216,7 +216,7 @@
     </Entry>
     <Entry>
       <ID>50</ID>
-      <DefaultText>Fellrüstungen werden üblicherweise von Waldläufer, glanfathanischen Entdeckern und jenen getragen, denen Geschwindigkeit wichtiger als Schutz ist. Fellrüstungen werden aus mehreren Schichten weicher Tierhaut angefertigt. Obwohl man für verlässlichen Schutz bei ihrer Herstellung mehrere Lederschichten benötigt, verlangsamt sie ihren Träger kaum.</DefaultText>
+      <DefaultText>Fellrüstungen werden üblicherweise von Waldläufern, glanfathanischen Entdeckern und jenen getragen, denen Geschwindigkeit wichtiger als Schutz ist. Fellrüstungen werden aus mehreren Schichten weicher Tierhaut angefertigt. Obwohl man für verlässlichen Schutz bei ihrer Herstellung mehrere Lederschichten benötigt, verlangsamt sie ihren Träger kaum.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -503,7 +503,7 @@ Aloths hübsche, sorgfältige Schönschrift bildet auf den Seiten einen ordentli
     </Entry>
     <Entry>
       <ID>260</ID>
-      <DefaultText>Diese langen Zweihandschwerter kann man durch ihre schmalen, pikenförmigen Spitzen leicht von normalen Großschwertern unterscheiden Panzerbrecher sind unter den Kriegern des Dyrwalds zwar nicht sehr verbreitet, ihr Wert gegen schwer gepanzerter Gegner ist aber unbestritten.</DefaultText>
+      <DefaultText>Diese langen Zweihandschwerter kann man durch ihre schmalen, pikenförmigen Spitzen leicht von normalen Großschwertern unterscheiden. Panzerbrecher sind unter den Kriegern des Dyrwalds zwar nicht sehr verbreitet, ihr Wert gegen schwer gepanzerte Gegner ist aber unbestritten.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>

--- a/laxg_exported/localized/de_patch/text/game/abilities.stringtable
+++ b/laxg_exported/localized/de_patch/text/game/abilities.stringtable
@@ -114,7 +114,7 @@ Gewährt &lt;link="gamedata://b6cd697b-176e-4fc3-b538-ae80a78d1ef3"&gt;Taktische
     </Entry>
     <Entry>
       <ID>4945</ID>
-      <DefaultText>Fügt, solange sie flankiert werden, Erschüttert und Verwirrt zu.</DefaultText>
+      <DefaultText>Sind, solange sie Flankiert werden, Erschüttert und Verwirrt.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -124,7 +124,7 @@ Gewährt &lt;link="gamedata://b6cd697b-176e-4fc3-b538-ae80a78d1ef3"&gt;Taktische
     </Entry>
     <Entry>
       <ID>4947</ID>
-      <DefaultText>Gewährt die Inspiration Brillant, solange alle Feinde, jedoch keine Verbündeten flankiert sind.</DefaultText>
+      <DefaultText>Gewährt die Inspiration Brillant, solange alle Feinde, jedoch keine Verbündeten Flankiert sind.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -229,7 +229,7 @@ Gewährt die Fähigkeit &lt;link="gamedata://b75184f8-63d7-44e3-901d-9c9205ad538
 Gewährt das Verwandeln von Treffern in leichte Treffer, wenn frei von Wirkungen.
 
 &lt;b&gt;Abzug&lt;/b&gt;
-Kann nicht angegriffen werden.
+Kann nicht angreifen.
 
 Gewährt die Fähigkeit &lt;link="gamedata://26890e79-a660-4593-ae57-08607d5cf296"&gt;Feigheit&lt;/link&gt;.</DefaultText>
       <FemaleText />
@@ -454,7 +454,7 @@ Lerne die folgenden Priesterzauber automatisch auf neuen Kraftstufen:
     </Entry>
     <Entry>
       <ID>5004</ID>
-      <DefaultText>Lenkt die göttliche Befehlsauthorität, auf dass allen in einem bestimmten Bereich die Heilung verboten ist. Dadurch werden die Ziele entkräftet und sind in der Möglichkeit eingeschränkt, in irgendeiner Weise Heilung zu empfangen.</DefaultText>
+      <DefaultText>Lenkt die göttliche Befehlsautorität, auf dass allen in einem bestimmten Bereich die Heilung verboten ist. Dadurch werden die Ziele entkräftet und sind in der Möglichkeit eingeschränkt, in irgendeiner Weise Heilung zu empfangen.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>
@@ -487,7 +487,7 @@ Erlittener Schaden deaktiviert kurzzeitig Seelenverstand.</DefaultText>
     </Entry>
     <Entry>
       <ID>5009</ID>
-      <DefaultText>Wenn der Verstand des Mediums frei ist, um sich zu konzentrieren, schärft er sich, wodurch das Medium auf verborgene Kräfte zuzugreifen und passiv Fokus generieren kann. Diese Wirkung wird jedoch kurzzeitig außer Kraft gesetzt, wenn das Medium durch einen Angriff Schaden erleidet.</DefaultText>
+      <DefaultText>Wenn der Verstand des Mediums frei ist, um sich zu konzentrieren, schärft er sich, wodurch das Medium auf verborgene Kräfte zugreifen und passiv Fokus generieren kann. Diese Wirkung wird jedoch kurzzeitig außer Kraft gesetzt, wenn das Medium durch einen Angriff Schaden erleidet.</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>


### PR DESCRIPTION
Mal wieder verschiedene Änderungen.
In LAXG ist in der abilities.stringtable ein Eintrag, der falsch übersetzt war ("cannot engage" - "kann nicht angegriffen werden"; das wäre ja auch kein Malus der Charakterklasse). Vllt. hast du eine Idee, wie man den besser übersetzen kann als "kann nicht angreifen". Es geht ja um die Angriffsbindung...